### PR TITLE
Implement command suggestions for Forge and Fabric

### DIFF
--- a/spark-fabric/src/main/java/me/lucko/spark/fabric/plugin/FabricSparkPlugin.java
+++ b/spark-fabric/src/main/java/me/lucko/spark/fabric/plugin/FabricSparkPlugin.java
@@ -26,6 +26,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import me.lucko.spark.common.SparkPlatform;
 import me.lucko.spark.common.SparkPlugin;
@@ -39,7 +40,7 @@ import java.util.concurrent.ScheduledExecutorService;
 
 public abstract class FabricSparkPlugin implements SparkPlugin {
 
-    public static <T> void registerCommands(CommandDispatcher<T> dispatcher, Command<T> executor, String... aliases) {
+    public static <T> void registerCommands(CommandDispatcher<T> dispatcher, Command<T> executor, SuggestionProvider<T> suggestor, String... aliases) {
         if (aliases.length == 0) {
             return;
         }
@@ -48,6 +49,7 @@ public abstract class FabricSparkPlugin implements SparkPlugin {
         LiteralArgumentBuilder<T> command = LiteralArgumentBuilder.<T>literal(mainName)
                 .executes(executor)
                 .then(RequiredArgumentBuilder.<T, String>argument("args", StringArgumentType.greedyString())
+                        .suggests(suggestor)
                         .executes(executor)
                 );
 

--- a/spark-forge/src/main/java/me/lucko/spark/forge/plugin/ForgeSparkPlugin.java
+++ b/spark-forge/src/main/java/me/lucko/spark/forge/plugin/ForgeSparkPlugin.java
@@ -26,6 +26,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import me.lucko.spark.common.SparkPlatform;
 import me.lucko.spark.common.SparkPlugin;
@@ -39,7 +40,7 @@ import java.util.concurrent.ScheduledExecutorService;
 
 public abstract class ForgeSparkPlugin implements SparkPlugin {
 
-    public static <T> void registerCommands(CommandDispatcher<T> dispatcher, Command<T> executor, String... aliases) {
+    public static <T> void registerCommands(CommandDispatcher<T> dispatcher, Command<T> executor, SuggestionProvider<T> suggestor, String... aliases) {
         if (aliases.length == 0) {
             return;
         }
@@ -48,6 +49,7 @@ public abstract class ForgeSparkPlugin implements SparkPlugin {
         LiteralArgumentBuilder<T> command = LiteralArgumentBuilder.<T>literal(mainName)
                 .executes(executor)
                 .then(RequiredArgumentBuilder.<T, String>argument("args", StringArgumentType.greedyString())
+                        .suggests(suggestor)
                         .executes(executor)
                 );
 


### PR DESCRIPTION
Also removed a reflection to access command dispatcher in client network handler in forge (a public getter method is already available to access the dispatcher)

The example of suggestion is as below (on fabric):
![suggestion example](https://user-images.githubusercontent.com/7806504/64058466-1b396500-cb71-11e9-9392-8bc687e8a1ef.png)
