### PR TITLE
Fix 1.14 support

### DIFF
--- a/spark-forge/src/main/resources/META-INF/mods.toml
+++ b/spark-forge/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[31,)"
+loaderVersion="[28,)"
 authors="Luck, sk89q"
 
 [[mods]]


### PR DESCRIPTION
One of the loader versions was still at `"[31,)"`, so it kept throwing `Mod File spark-forge.jar needs language provider javafml:31 or above to load` on my 1.14 server.