### PR TITLE
fix compatibility on multiplayer screen.

### DIFF
--- a/spark-forge/src/main/java/me/lucko/spark/forge/ForgeSparkMod.java
+++ b/spark-forge/src/main/java/me/lucko/spark/forge/ForgeSparkMod.java
@@ -24,6 +24,7 @@ import me.lucko.spark.forge.plugin.ForgeClientSparkPlugin;
 import me.lucko.spark.forge.plugin.ForgeServerSparkPlugin;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ExtensionPoint;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
@@ -32,6 +33,8 @@ import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.server.FMLServerStartingEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.loading.FMLPaths;
+import net.minecraftforge.fml.network.FMLNetworkConstants;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.nio.file.Path;
 
@@ -44,6 +47,7 @@ public class ForgeSparkMod {
     public ForgeSparkMod() {
         FMLJavaModLoadingContext.get().getModEventBus().register(this);
         MinecraftForge.EVENT_BUS.register(this);
+        ModLoadingContext.get().registerExtensionPoint(ExtensionPoint.DISPLAYTEST, () -> Pair.of(() -> FMLNetworkConstants.IGNORESERVERONLY, (a, b) -> true));
     }
 
     public String getVersion() {


### PR DESCRIPTION
This change makes it so that spark shows as compatible on the multiplayer screen even when it is only installed on one side. 

https://mcforge.readthedocs.io/en/latest/concepts/sides/#writing-one-sided-mods

Fixes this: 
![image](https://user-images.githubusercontent.com/4283717/81824149-6e9fe780-9535-11ea-8f4f-b041c2ec1323.png)
