### PR TITLE
make spark work from external commandsources

### DIFF
--- a/spark-forge/build.gradle
+++ b/spark-forge/build.gradle
@@ -15,6 +15,7 @@ apply plugin: 'net.minecraftforge.gradle'
 
 minecraft {
     mappings channel: 'snapshot', version: '20200125-1.15.1'
+    accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
 }
 
 processResources {

--- a/spark-forge/src/main/java/me/lucko/spark/forge/plugin/ForgeServerSparkPlugin.java
+++ b/spark-forge/src/main/java/me/lucko/spark/forge/plugin/ForgeServerSparkPlugin.java
@@ -79,8 +79,7 @@ public class ForgeServerSparkPlugin extends ForgeSparkPlugin implements Command<
         String[] args = processArgs(context);
         if (args == null)
             return 0;
-        ICommandSource source = context.getSource().getEntity() instanceof ServerPlayerEntity ? context.getSource().asPlayer() : context.getSource().getServer();
-        this.platform.executeCommand(new ForgeCommandSender(source, this), args);
+        this.platform.executeCommand(new ForgeCommandSender(context.getSource().source, this), args);
         return Command.SINGLE_SUCCESS;
     }
 

--- a/spark-forge/src/main/resources/META-INF/accesstransformer.cfg
+++ b/spark-forge/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,0 +1,1 @@
+public net.minecraft.command.CommandSource field_197041_c # source


### PR DESCRIPTION
Improves on #40 and makes spark work from sources other than the console itself. 

For example from Discord: 
![image](https://user-images.githubusercontent.com/4283717/81844365-402f0600-954f-11ea-84fc-deec17aa161e.png)
