### PR TITLE
Add 95th percentile MSPT and replace average MSPT with median MSPT

### DIFF
--- a/spark-bukkit/src/main/java/me/lucko/spark/bukkit/placeholder/SparkPlaceholderProvider.java
+++ b/spark-bukkit/src/main/java/me/lucko/spark/bukkit/placeholder/SparkPlaceholderProvider.java
@@ -68,12 +68,9 @@ enum SparkPlaceholderProvider {
             switch (placeholder) {
                 case "tickduration":
                     return TextComponent.builder("")
-                            .append(HealthModule.formatTickDurations(tickStatistics.duration5Sec())).append(TextComponent.of(", "))
-                            .append(HealthModule.formatTickDurations(tickStatistics.duration10Sec())).append(TextComponent.of(", "))
+                            .append(HealthModule.formatTickDurations(tickStatistics.duration10Sec())).append(TextComponent.of(";  "))
                             .append(HealthModule.formatTickDurations(tickStatistics.duration1Min()))
                             .build();
-                case "tickduration_5s":
-                    return HealthModule.formatTickDurations(tickStatistics.duration5Sec());
                 case "tickduration_10s":
                     return HealthModule.formatTickDurations(tickStatistics.duration10Sec());
                 case "tickduration_1m":

--- a/spark-common/src/main/java/me/lucko/spark/common/command/modules/HealthModule.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/command/modules/HealthModule.java
@@ -69,10 +69,9 @@ public class HealthModule implements CommandModule {
                         resp.replyPrefixed(TextComponent.empty());
 
                         if (tickStatistics.isDurationSupported()) {
-                            resp.replyPrefixed(TextComponent.of("Tick durations (min/med/95%ile/max ms) from last 5s, 10s, 1m:"));
+                            resp.replyPrefixed(TextComponent.of("Tick durations (min/med/95%ile/max ms) from last 10s, 1m:"));
                             resp.replyPrefixed(TextComponent.builder(" ")
-                                    .append(formatTickDurations(tickStatistics.duration5Sec())).append(TextComponent.of(", "))
-                                    .append(formatTickDurations(tickStatistics.duration10Sec())).append(TextComponent.of(", "))
+                                    .append(formatTickDurations(tickStatistics.duration10Sec())).append(TextComponent.of(";  "))
                                     .append(formatTickDurations(tickStatistics.duration1Min()))
                                     .build()
                             );
@@ -131,12 +130,11 @@ public class HealthModule implements CommandModule {
                                 report.add(TextComponent.builder("")
                                         .append(TextComponent.builder(">").color(TextColor.DARK_GRAY).decoration(TextDecoration.BOLD, true).build())
                                         .append(TextComponent.space())
-                                        .append(TextComponent.of("Tick durations (min/med/95%ile/max ms) from last 5s, 10s, 1m:", TextColor.GOLD))
+                                        .append(TextComponent.of("Tick durations (min/med/95%ile/max ms) from last 10s, 1m:", TextColor.GOLD))
                                         .build()
                                 );
                                 report.add(TextComponent.builder("    ")
-                                        .append(formatTickDurations(tickStatistics.duration5Sec())).append(TextComponent.of(", "))
-                                        .append(formatTickDurations(tickStatistics.duration10Sec())).append(TextComponent.of(", "))
+                                        .append(formatTickDurations(tickStatistics.duration10Sec())).append(TextComponent.of("; "))
                                         .append(formatTickDurations(tickStatistics.duration1Min()))
                                         .build()
                                 );

--- a/spark-common/src/main/java/me/lucko/spark/common/command/modules/HealthModule.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/command/modules/HealthModule.java
@@ -69,7 +69,7 @@ public class HealthModule implements CommandModule {
                         resp.replyPrefixed(TextComponent.empty());
 
                         if (tickStatistics.isDurationSupported()) {
-                            resp.replyPrefixed(TextComponent.of("Tick durations (min/avg/95%ile/max ms) from last 5s, 10s, 1m:"));
+                            resp.replyPrefixed(TextComponent.of("Tick durations (min/med/95%ile/max ms) from last 5s, 10s, 1m:"));
                             resp.replyPrefixed(TextComponent.builder(" ")
                                     .append(formatTickDurations(tickStatistics.duration5Sec())).append(TextComponent.of(", "))
                                     .append(formatTickDurations(tickStatistics.duration10Sec())).append(TextComponent.of(", "))
@@ -131,7 +131,7 @@ public class HealthModule implements CommandModule {
                                 report.add(TextComponent.builder("")
                                         .append(TextComponent.builder(">").color(TextColor.DARK_GRAY).decoration(TextDecoration.BOLD, true).build())
                                         .append(TextComponent.space())
-                                        .append(TextComponent.of("Tick durations (min/avg/95%ile/max ms) from last 5s, 10s, 1m:", TextColor.GOLD))
+                                        .append(TextComponent.of("Tick durations (min/med/95%ile/max ms) from last 5s, 10s, 1m:", TextColor.GOLD))
                                         .build()
                                 );
                                 report.add(TextComponent.builder("    ")
@@ -303,7 +303,7 @@ public class HealthModule implements CommandModule {
         return TextComponent.builder("")
                 .append(formatTickDuration(average.getMin()))
                 .append(TextComponent.of('/', TextColor.GRAY))
-                .append(formatTickDuration(average.getAverage()))
+                .append(formatTickDuration(average.getMedian()))
                 .append(TextComponent.of('/', TextColor.GRAY))
                 .append(formatTickDuration(average.getPercentile(MSPT_95_PERCENTILE)))
                 .append(TextComponent.of('/', TextColor.GRAY))

--- a/spark-common/src/main/java/me/lucko/spark/common/command/modules/HealthModule.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/command/modules/HealthModule.java
@@ -48,6 +48,8 @@ import java.util.function.Consumer;
 
 public class HealthModule implements CommandModule {
 
+    private static final int MSPT_95_PERCENTILE = 95;
+
     @Override
     public void registerCommands(Consumer<Command> consumer) {
         consumer.accept(Command.builder()
@@ -67,7 +69,7 @@ public class HealthModule implements CommandModule {
                         resp.replyPrefixed(TextComponent.empty());
 
                         if (tickStatistics.isDurationSupported()) {
-                            resp.replyPrefixed(TextComponent.of("Tick durations (avg/min/max ms) from last 5s, 10s, 1m:"));
+                            resp.replyPrefixed(TextComponent.of("Tick durations (min/avg/95th %ile/max ms) from last 5s, 10s, 1m:"));
                             resp.replyPrefixed(TextComponent.builder(" ")
                                     .append(formatTickDurations(tickStatistics.duration5Sec())).append(TextComponent.of(", "))
                                     .append(formatTickDurations(tickStatistics.duration10Sec())).append(TextComponent.of(", "))
@@ -129,7 +131,7 @@ public class HealthModule implements CommandModule {
                                 report.add(TextComponent.builder("")
                                         .append(TextComponent.builder(">").color(TextColor.DARK_GRAY).decoration(TextDecoration.BOLD, true).build())
                                         .append(TextComponent.space())
-                                        .append(TextComponent.of("Tick durations (avg/min/max ms) from last 5s, 10s, 1m:", TextColor.GOLD))
+                                        .append(TextComponent.of("Tick durations (min/avg/95%ile/max ms) from last 5s, 10s, 1m:", TextColor.GOLD))
                                         .build()
                                 );
                                 report.add(TextComponent.builder("    ")
@@ -299,9 +301,11 @@ public class HealthModule implements CommandModule {
 
     public static TextComponent formatTickDurations(RollingAverage average){
         return TextComponent.builder("")
+                .append(formatTickDuration(average.getMin()))
+                .append(TextComponent.of('/', TextColor.GRAY))
                 .append(formatTickDuration(average.getAverage()))
                 .append(TextComponent.of('/', TextColor.GRAY))
-                .append(formatTickDuration(average.getMin()))
+                .append(formatTickDuration(average.getPercentile(MSPT_95_PERCENTILE)))
                 .append(TextComponent.of('/', TextColor.GRAY))
                 .append(formatTickDuration(average.getMax()))
                 .build();

--- a/spark-common/src/main/java/me/lucko/spark/common/command/modules/HealthModule.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/command/modules/HealthModule.java
@@ -69,7 +69,7 @@ public class HealthModule implements CommandModule {
                         resp.replyPrefixed(TextComponent.empty());
 
                         if (tickStatistics.isDurationSupported()) {
-                            resp.replyPrefixed(TextComponent.of("Tick durations (min/avg/95th %ile/max ms) from last 5s, 10s, 1m:"));
+                            resp.replyPrefixed(TextComponent.of("Tick durations (min/avg/95%ile/max ms) from last 5s, 10s, 1m:"));
                             resp.replyPrefixed(TextComponent.builder(" ")
                                     .append(formatTickDurations(tickStatistics.duration5Sec())).append(TextComponent.of(", "))
                                     .append(formatTickDurations(tickStatistics.duration10Sec())).append(TextComponent.of(", "))

--- a/spark-common/src/main/java/me/lucko/spark/common/monitor/tick/TickStatistics.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/monitor/tick/TickStatistics.java
@@ -54,10 +54,9 @@ public class TickStatistics implements TickHook.Callback, TickReporter.Callback 
     private final TpsRollingAverage[] tpsAverages = {this.tps5Sec, this.tps10Sec, this.tps1Min, this.tps5Min, this.tps15Min};
 
     private boolean durationSupported = false;
-    private final RollingAverage tickDuration5Sec = new RollingAverage(TPS * 5);
     private final RollingAverage tickDuration10Sec = new RollingAverage(TPS * 10);
     private final RollingAverage tickDuration1Min = new RollingAverage(TPS * 60);
-    private final RollingAverage[] tickDurationAverages = {this.tickDuration5Sec, this.tickDuration10Sec, this.tickDuration1Min};
+    private final RollingAverage[] tickDurationAverages = {this.tickDuration10Sec, this.tickDuration1Min};
 
     private long last = 0;
 
@@ -116,13 +115,6 @@ public class TickStatistics implements TickHook.Callback, TickReporter.Callback 
 
     public double tps15Min() {
         return this.tps15Min.getAverage();
-    }
-
-    public RollingAverage duration5Sec() {
-        if (!this.durationSupported) {
-            return null;
-        }
-        return this.tickDuration5Sec;
     }
 
     public RollingAverage duration10Sec() {

--- a/spark-common/src/main/java/me/lucko/spark/common/util/RollingAverage.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/util/RollingAverage.java
@@ -20,9 +20,13 @@
 
 package me.lucko.spark.common.util;
 
+import com.google.common.collect.Iterables;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Queue;
 
 public class RollingAverage {
@@ -77,6 +81,24 @@ public class RollingAverage {
             }
             return min.doubleValue();
         }
+    }
+
+    public double getPercentile(int percentile) {
+        if (percentile < 0 || percentile > 100) {
+            throw new IllegalArgumentException("Invalid percentage " + percentile);
+        }
+
+        List<BigDecimal> sortedSamples;
+        synchronized (this) {
+            if (this.samples.isEmpty()) {
+                return 0;
+            }
+            sortedSamples = new ArrayList<>(this.samples);
+        }
+        sortedSamples.sort(null);
+
+        int rank = (int) Math.ceil((percentile / 100d) * sortedSamples.size());
+        return sortedSamples.get(rank).doubleValue();
     }
 
 }

--- a/spark-common/src/main/java/me/lucko/spark/common/util/RollingAverage.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/util/RollingAverage.java
@@ -20,8 +20,6 @@
 
 package me.lucko.spark.common.util;
 
-import com.google.common.collect.Iterables;
-
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayDeque;
@@ -81,6 +79,10 @@ public class RollingAverage {
             }
             return min.doubleValue();
         }
+    }
+
+    public double getMedian() {
+        return getPercentile(50);
     }
 
     public double getPercentile(int percentile) {


### PR DESCRIPTION
The current set of MSPT measures provided by spark today are average MSPT, absolute minimum MSPT, and absolute maximum MSPT. All three measures are highly misleading, since the distribution of tick times tends to be skewed.

For performance tracking, you really want percentiles. Due to the limited room in-game, we can only comfortably fit 4 measures. I've replaced average MSPT with median MSPT (this is just the 50th percentile) and added the 95th percentile MSPT.

The median is a better choice for MSPT as it is a resistant statistic - one that is much less likely to change when extremes are present in the list. Thus, the median MSPT is a better measure of overall server performance over time. If your median MSPT is very high, then it means you have a serious performance problem and optimizations are in order.

I added the 95th percentile MSPT to better illustrate the highest general overall MSPT that a server has. The 95th percentile MSPT is volatile, but it will keep away most of the extremes when measuring the time it takes for the server to tick, such as GC pauses.

In addition, the 5 second MSPT has been removed - it's very volatile. The 10-second MSPT measure does just as good of a job.