### PR TITLE
Include platform info in sampler and heap summary data

### DIFF
--- a/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitPlatformInfo.java
+++ b/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitPlatformInfo.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.bukkit;
+
+import me.lucko.spark.common.PlatformInfo;
+import org.bukkit.Bukkit;
+
+public class BukkitPlatformInfo implements PlatformInfo {
+    @Override
+    public Type getType() {
+        return Type.SERVER;
+    }
+
+    @Override
+    public String getName() {
+        return "Bukkit";
+    }
+
+    @Override
+    public String getVersion() {
+        return Bukkit.getVersion();
+    }
+
+    @Override
+    public String getMinecraftVersion() {
+        return Bukkit.getMinecraftVersion();
+    }
+}

--- a/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitSparkPlugin.java
+++ b/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitSparkPlugin.java
@@ -24,6 +24,7 @@ import me.lucko.spark.bukkit.placeholder.SparkMVdWPlaceholders;
 import me.lucko.spark.bukkit.placeholder.SparkPlaceholderApi;
 import me.lucko.spark.common.SparkPlatform;
 import me.lucko.spark.common.SparkPlugin;
+import me.lucko.spark.common.PlatformInfo;
 import me.lucko.spark.common.sampler.ThreadDumper;
 import me.lucko.spark.common.sampler.tick.TickHook;
 import me.lucko.spark.common.sampler.tick.TickReporter;
@@ -146,6 +147,11 @@ public class BukkitSparkPlugin extends JavaPlugin implements SparkPlugin {
             return new PaperTickReporter(this);
         }
         return null;
+    }
+
+    @Override
+    public PlatformInfo getPlatformInfo() {
+        return new BukkitPlatformInfo();
     }
 
     private static boolean classExists(String className) {

--- a/spark-bungeecord/src/main/java/me/lucko/spark/bungeecord/BungeeCordPlatformInfo.java
+++ b/spark-bungeecord/src/main/java/me/lucko/spark/bungeecord/BungeeCordPlatformInfo.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.bungeecord;
+
+import me.lucko.spark.common.PlatformInfo;
+import net.md_5.bungee.api.ProxyServer;
+
+public class BungeeCordPlatformInfo implements PlatformInfo {
+    @Override
+    public Type getType() {
+        return Type.PROXY;
+    }
+
+    @Override
+    public String getName() {
+        return "BungeeCord";
+    }
+
+    @Override
+    public String getVersion() {
+        return ProxyServer.getInstance().getVersion();
+    }
+
+    @Override
+    public String getMinecraftVersion() {
+        return null;
+    }
+}

--- a/spark-bungeecord/src/main/java/me/lucko/spark/bungeecord/BungeeCordSparkPlugin.java
+++ b/spark-bungeecord/src/main/java/me/lucko/spark/bungeecord/BungeeCordSparkPlugin.java
@@ -22,6 +22,7 @@ package me.lucko.spark.bungeecord;
 
 import me.lucko.spark.common.SparkPlatform;
 import me.lucko.spark.common.SparkPlugin;
+import me.lucko.spark.common.PlatformInfo;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.plugin.Command;
 import net.md_5.bungee.api.plugin.Plugin;
@@ -72,6 +73,11 @@ public class BungeeCordSparkPlugin extends Plugin implements SparkPlugin {
     @Override
     public void executeAsync(Runnable task) {
         getProxy().getScheduler().runAsync(BungeeCordSparkPlugin.this, task);
+    }
+
+    @Override
+    public PlatformInfo getPlatformInfo() {
+        return new BungeeCordPlatformInfo();
     }
 
     private static final class SparkCommand extends Command implements TabExecutor {

--- a/spark-common/src/main/java/me/lucko/spark/common/PlatformInfo.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/PlatformInfo.java
@@ -1,0 +1,145 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.common;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import me.lucko.spark.proto.SparkProtos.PlatformData;
+
+public interface PlatformInfo {
+
+    Type getType();
+
+    String getName();
+
+    String getVersion();
+
+    String getMinecraftVersion();
+
+    default Data toData() {
+        return new Data(getType(), getName(), getVersion(), getMinecraftVersion());
+    }
+
+    enum Type {
+        SERVER(PlatformData.Type.SERVER),
+        CLIENT(PlatformData.Type.CLIENT),
+        PROXY(PlatformData.Type.PROXY);
+
+        private final PlatformData.Type type;
+
+        Type(PlatformData.Type type) {
+            this.type = type;
+        }
+
+        public PlatformData.Type toProto() {
+            return type;
+        }
+
+        public static Type fromProto(PlatformData.Type proto) {
+            for (Type type : values()) {
+                if (type.toProto() == proto) {
+                    return type;
+                }
+            }
+
+            return null;
+        }
+
+        public String getName() {
+            return super.name().toLowerCase();
+        }
+
+        public static Type fromName(String name) {
+            return valueOf(name.toUpperCase());
+        }
+    }
+
+    final class Data {
+        private final Type type;
+        private final String name;
+        private final String version;
+        private final String minecraftVersion;
+
+        public Data(Type type, String name, String version, String minecraftVersion) {
+            this.type = type;
+            this.name = name;
+            this.version = version;
+            this.minecraftVersion = minecraftVersion;
+        }
+
+        public Type getType() {
+            return type;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        public String getMinecraftVersion() {
+            return minecraftVersion;
+        }
+
+        // TODO: decide if necessary
+        public JsonObject serialize() {
+            JsonObject server = new JsonObject();
+            server.add("type", new JsonPrimitive(this.type.toString().toLowerCase()));
+            server.add("name", new JsonPrimitive(this.name));
+            server.add("version", new JsonPrimitive(this.version));
+            if (this.minecraftVersion != null) {
+                server.add("minecraftVersion", new JsonPrimitive(this.minecraftVersion));
+            }
+            return server;
+        }
+
+        public PlatformData toProto() {
+            PlatformData.Builder proto = PlatformData.newBuilder()
+                    .setType(this.type.toProto())
+                    .setName(this.name)
+                    .setVersion(this.version);
+
+            if (this.minecraftVersion != null) {
+                proto.setMinecraftVersion(this.minecraftVersion);
+            }
+
+            return proto.build();
+        }
+
+        // TODO: decide if necessary
+        public static PlatformInfo.Data deserialize(JsonElement element) {
+            JsonObject serverObject = element.getAsJsonObject();
+            Type type = Type.fromName(serverObject.get("type").getAsJsonPrimitive().getAsString());
+            String name = serverObject.get("name").getAsJsonPrimitive().getAsString();
+            String version = serverObject.get("version").getAsJsonPrimitive().getAsString();
+            String minecraftVersion;
+            if (serverObject.has("minecraftVersion")) {
+                minecraftVersion = serverObject.get("minecraftVersion").getAsJsonPrimitive().getAsString();
+            } else {
+                minecraftVersion = null;
+            }
+            return new PlatformInfo.Data(type, name, version, minecraftVersion);
+        }
+    }
+}

--- a/spark-common/src/main/java/me/lucko/spark/common/SparkPlugin.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/SparkPlugin.java
@@ -101,4 +101,11 @@ public interface SparkPlugin {
         return null;
     }
 
+    /**
+     * Gets information for the platform.
+     *
+     * @return information about the platform
+     */
+    PlatformInfo getPlatformInfo();
+
 }

--- a/spark-common/src/main/java/me/lucko/spark/common/command/modules/HeapAnalysisModule.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/command/modules/HeapAnalysisModule.java
@@ -76,7 +76,7 @@ public class HeapAnalysisModule implements CommandModule {
                             return;
                         }
 
-                        byte[] output = heapDump.formCompressedDataPayload(sender);
+                        byte[] output = heapDump.formCompressedDataPayload(platform.getPlugin().getPlatformInfo(), sender);
                         try {
                             String key = SparkPlatform.BYTEBIN_CLIENT.postContent(output, SPARK_HEAP_MEDIA_TYPE, false).key();
                             String url = SparkPlatform.VIEWER_URL + key;

--- a/spark-common/src/main/java/me/lucko/spark/common/command/modules/SamplerModule.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/command/modules/SamplerModule.java
@@ -267,7 +267,7 @@ public class SamplerModule implements CommandModule {
 
     private void handleUpload(SparkPlatform platform, CommandResponseHandler resp, Sampler sampler, ThreadNodeOrder threadOrder, String comment, MergeMode mergeMode) {
         platform.getPlugin().executeAsync(() -> {
-            byte[] output = sampler.formCompressedDataPayload(resp.sender(), threadOrder, comment, mergeMode);
+            byte[] output = sampler.formCompressedDataPayload(platform.getPlugin().getPlatformInfo(), resp.sender(), threadOrder, comment, mergeMode);
             try {
                 String key = SparkPlatform.BYTEBIN_CLIENT.postContent(output, SPARK_SAMPLER_MEDIA_TYPE, false).key();
                 String url = SparkPlatform.VIEWER_URL + key;

--- a/spark-common/src/main/java/me/lucko/spark/common/heapdump/HeapDumpSummary.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/heapdump/HeapDumpSummary.java
@@ -21,6 +21,7 @@
 package me.lucko.spark.common.heapdump;
 
 import me.lucko.spark.common.command.sender.CommandSender;
+import me.lucko.spark.common.PlatformInfo;
 import me.lucko.spark.proto.SparkProtos;
 import me.lucko.spark.proto.SparkProtos.HeapData;
 import me.lucko.spark.proto.SparkProtos.HeapEntry;
@@ -127,9 +128,10 @@ public final class HeapDumpSummary {
         this.entries = entries;
     }
 
-    private HeapData toProto(CommandSender creator) {
+    private HeapData toProto(PlatformInfo platformInfo, CommandSender creator) {
         HeapData.Builder proto = HeapData.newBuilder();
         proto.setMetadata(SparkProtos.HeapMetadata.newBuilder()
+                .setPlatform(platformInfo.toData().toProto())
                 .setUser(creator.toData().toProto())
                 .build()
         );
@@ -141,10 +143,10 @@ public final class HeapDumpSummary {
         return proto.build();
     }
 
-    public byte[] formCompressedDataPayload(CommandSender creator) {
+    public byte[] formCompressedDataPayload(PlatformInfo platformInfo, CommandSender creator) {
         ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
         try (OutputStream out = new GZIPOutputStream(byteOut)) {
-            toProto(creator).writeTo(out);
+            toProto(platformInfo, creator).writeTo(out);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/Sampler.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/Sampler.java
@@ -23,6 +23,7 @@ package me.lucko.spark.common.sampler;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import me.lucko.spark.common.command.sender.CommandSender;
+import me.lucko.spark.common.PlatformInfo;
 import me.lucko.spark.common.sampler.aggregator.DataAggregator;
 import me.lucko.spark.common.sampler.aggregator.SimpleDataAggregator;
 import me.lucko.spark.common.sampler.aggregator.TickedDataAggregator;
@@ -161,8 +162,9 @@ public class Sampler implements Runnable {
         }
     }
 
-    private SamplerData toProto(CommandSender creator, Comparator<? super Map.Entry<String, ThreadNode>> outputOrder, String comment, MergeMode mergeMode) {
+    private SamplerData toProto(PlatformInfo platformInfo, CommandSender creator, Comparator<? super Map.Entry<String, ThreadNode>> outputOrder, String comment, MergeMode mergeMode) {
         final SamplerMetadata.Builder metadata = SamplerMetadata.newBuilder()
+                .setPlatform(platformInfo.toData().toProto())
                 .setUser(creator.toData().toProto())
                 .setStartTime(this.startTime)
                 .setInterval(this.interval)
@@ -186,8 +188,8 @@ public class Sampler implements Runnable {
         return proto.build();
     }
 
-    public byte[] formCompressedDataPayload(CommandSender creator, Comparator<? super Map.Entry<String, ThreadNode>> outputOrder, String comment, MergeMode mergeMode) {
-        SamplerData proto = toProto(creator, outputOrder, comment, mergeMode);
+    public byte[] formCompressedDataPayload(PlatformInfo platformInfo, CommandSender creator, Comparator<? super Map.Entry<String, ThreadNode>> outputOrder, String comment, MergeMode mergeMode) {
+        SamplerData proto = toProto(platformInfo, creator, outputOrder, comment, mergeMode);
 
         ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
         try (OutputStream out = new GZIPOutputStream(byteOut)) {

--- a/spark-common/src/main/proto/spark/spark.proto
+++ b/spark-common/src/main/proto/spark/spark.proto
@@ -16,6 +16,19 @@ message CommandSenderData {
   }
 }
 
+message PlatformData {
+  Type type = 1;
+  string name = 2;
+  string version = 3;
+  string minecraft_version = 4; // optional
+
+  enum Type {
+    SERVER = 0;
+    CLIENT = 1;
+    PROXY = 2;
+  }
+}
+
 message HeapData {
   HeapMetadata metadata = 1;
   repeated HeapEntry entries = 2;
@@ -23,6 +36,7 @@ message HeapData {
 
 message HeapMetadata {
   CommandSenderData user = 1;
+  PlatformData platform = 2;
 }
 
 message HeapEntry {
@@ -44,6 +58,7 @@ message SamplerMetadata {
   ThreadDumper thread_dumper = 4;
   DataAggregator data_aggregator = 5;
   string comment = 6;
+  PlatformData platform = 7;
 
   message ThreadDumper {
     Type type = 1;

--- a/spark-fabric/src/main/java/me/lucko/spark/fabric/FabricPlatformInfo.java
+++ b/spark-fabric/src/main/java/me/lucko/spark/fabric/FabricPlatformInfo.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.fabric;
+
+import me.lucko.spark.common.PlatformInfo;
+import net.fabricmc.loader.api.FabricLoader;
+
+import java.util.Optional;
+
+public class FabricPlatformInfo implements PlatformInfo {
+
+    private final Type type;
+
+    public FabricPlatformInfo(Type type) {
+        this.type = type;
+    }
+
+    @Override
+    public Type getType() {
+        return type;
+    }
+
+    @Override
+    public String getName() {
+        return "Fabric";
+    }
+
+    @Override
+    public String getVersion() {
+        return getModVersion("fabricloader").orElse("unknown");
+    }
+
+    @Override
+    public String getMinecraftVersion() {
+        return getModVersion("minecraft").orElse(null);
+    }
+
+    private Optional<String> getModVersion(String mod) {
+        return FabricLoader.getInstance().getModContainer(mod).map(container -> container.getMetadata().getVersion().getFriendlyString());
+    }
+}

--- a/spark-fabric/src/main/java/me/lucko/spark/fabric/plugin/FabricClientSparkPlugin.java
+++ b/spark-fabric/src/main/java/me/lucko/spark/fabric/plugin/FabricClientSparkPlugin.java
@@ -27,11 +27,9 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import me.lucko.spark.common.PlatformInfo;
 import me.lucko.spark.common.sampler.tick.TickHook;
-import me.lucko.spark.fabric.FabricCommandSender;
-import me.lucko.spark.fabric.FabricSparkGameHooks;
-import me.lucko.spark.fabric.FabricSparkMod;
-import me.lucko.spark.fabric.FabricTickHook;
+import me.lucko.spark.fabric.*;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.server.command.CommandOutput;
@@ -124,6 +122,11 @@ public class FabricClientSparkPlugin extends FabricSparkPlugin implements Sugges
     @Override
     public TickHook createTickHook() {
         return new FabricTickHook.Client();
+    }
+
+    @Override
+    public PlatformInfo getPlatformInfo() {
+        return new FabricPlatformInfo(PlatformInfo.Type.CLIENT);
     }
 
     @Override

--- a/spark-fabric/src/main/java/me/lucko/spark/fabric/plugin/FabricServerSparkPlugin.java
+++ b/spark-fabric/src/main/java/me/lucko/spark/fabric/plugin/FabricServerSparkPlugin.java
@@ -26,8 +26,10 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import me.lucko.spark.common.PlatformInfo;
 import me.lucko.spark.common.sampler.tick.TickHook;
 import me.lucko.spark.fabric.FabricCommandSender;
+import me.lucko.spark.fabric.FabricPlatformInfo;
 import me.lucko.spark.fabric.FabricSparkMod;
 import me.lucko.spark.fabric.FabricTickHook;
 import net.fabricmc.fabric.api.registry.CommandRegistry;
@@ -113,6 +115,11 @@ public class FabricServerSparkPlugin extends FabricSparkPlugin implements Comman
     @Override
     public TickHook createTickHook() {
         return new FabricTickHook.Server();
+    }
+
+    @Override
+    public PlatformInfo getPlatformInfo() {
+        return new FabricPlatformInfo(PlatformInfo.Type.SERVER);
     }
 
     @Override

--- a/spark-forge/src/main/java/me/lucko/spark/forge/ForgePlatformInfo.java
+++ b/spark-forge/src/main/java/me/lucko/spark/forge/ForgePlatformInfo.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.forge;
+
+import me.lucko.spark.common.PlatformInfo;
+import net.minecraftforge.versions.forge.ForgeVersion;
+import net.minecraftforge.versions.mcp.MCPVersion;
+
+public class ForgePlatformInfo implements PlatformInfo {
+
+    private final Type type;
+
+    public ForgePlatformInfo(Type type) {
+        this.type = type;
+    }
+
+    @Override
+    public Type getType() {
+        return type;
+    }
+
+    @Override
+    public String getName() {
+        return "Forge";
+    }
+
+    @Override
+    public String getVersion() {
+        return ForgeVersion.getVersion();
+    }
+
+    @Override
+    public String getMinecraftVersion() {
+        return MCPVersion.getMCVersion();
+    }
+}

--- a/spark-forge/src/main/java/me/lucko/spark/forge/plugin/ForgeClientSparkPlugin.java
+++ b/spark-forge/src/main/java/me/lucko/spark/forge/plugin/ForgeClientSparkPlugin.java
@@ -27,12 +27,10 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import me.lucko.spark.common.PlatformInfo;
 import me.lucko.spark.common.sampler.tick.TickHook;
 import me.lucko.spark.common.sampler.tick.TickReporter;
-import me.lucko.spark.forge.ForgeCommandSender;
-import me.lucko.spark.forge.ForgeSparkMod;
-import me.lucko.spark.forge.ForgeTickHook;
-import me.lucko.spark.forge.ForgeTickReporter;
+import me.lucko.spark.forge.*;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.network.play.ClientPlayNetHandler;
 import net.minecraft.command.ICommandSource;
@@ -141,6 +139,11 @@ public class ForgeClientSparkPlugin extends ForgeSparkPlugin implements Suggesti
     @Override
     public TickReporter createTickReporter() {
         return new ForgeTickReporter(TickEvent.Type.CLIENT);
+    }
+
+    @Override
+    public PlatformInfo getPlatformInfo() {
+        return new ForgePlatformInfo(PlatformInfo.Type.CLIENT);
     }
 
     @Override

--- a/spark-forge/src/main/java/me/lucko/spark/forge/plugin/ForgeServerSparkPlugin.java
+++ b/spark-forge/src/main/java/me/lucko/spark/forge/plugin/ForgeServerSparkPlugin.java
@@ -27,12 +27,10 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import me.lucko.spark.common.PlatformInfo;
 import me.lucko.spark.common.sampler.tick.TickHook;
 import me.lucko.spark.common.sampler.tick.TickReporter;
-import me.lucko.spark.forge.ForgeCommandSender;
-import me.lucko.spark.forge.ForgeSparkMod;
-import me.lucko.spark.forge.ForgeTickHook;
-import me.lucko.spark.forge.ForgeTickReporter;
+import me.lucko.spark.forge.*;
 import net.minecraft.command.CommandSource;
 import net.minecraft.command.ICommandSource;
 import net.minecraft.entity.player.PlayerEntity;
@@ -124,6 +122,11 @@ public class ForgeServerSparkPlugin extends ForgeSparkPlugin implements Command<
     @Override
     public TickReporter createTickReporter() {
         return new ForgeTickReporter(TickEvent.Type.SERVER);
+    }
+
+    @Override
+    public PlatformInfo getPlatformInfo() {
+        return new ForgePlatformInfo(PlatformInfo.Type.SERVER);
     }
 
     @Override

--- a/spark-forge/src/main/java/me/lucko/spark/forge/plugin/ForgeSparkPlugin.java
+++ b/spark-forge/src/main/java/me/lucko/spark/forge/plugin/ForgeSparkPlugin.java
@@ -93,4 +93,5 @@ public abstract class ForgeSparkPlugin implements SparkPlugin {
     public ThreadDumper getDefaultThreadDumper() {
         return new ThreadDumper.Specific(new long[]{Thread.currentThread().getId()});
     }
+
 }

--- a/spark-sponge/src/main/java/me/lucko/spark/sponge/SpongePlatformInfo.java
+++ b/spark-sponge/src/main/java/me/lucko/spark/sponge/SpongePlatformInfo.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.sponge;
+
+import me.lucko.spark.common.PlatformInfo;
+import org.spongepowered.api.Platform;
+import org.spongepowered.api.Sponge;
+
+public class SpongePlatformInfo implements PlatformInfo {
+    @Override
+    public Type getType() {
+        return Type.SERVER;
+    }
+
+    @Override
+    public String getName() {
+        return "Sponge";
+    }
+
+    @Override
+    public String getVersion() {
+        return Sponge.getPlatform().getContainer(Platform.Component.IMPLEMENTATION).getVersion().orElse("unknown");
+    }
+
+    @Override
+    public String getMinecraftVersion() {
+        return Sponge.getPlatform().getMinecraftVersion().getName();
+    }
+}

--- a/spark-sponge/src/main/java/me/lucko/spark/sponge/SpongeSparkPlugin.java
+++ b/spark-sponge/src/main/java/me/lucko/spark/sponge/SpongeSparkPlugin.java
@@ -23,6 +23,7 @@ package me.lucko.spark.sponge;
 import com.google.inject.Inject;
 import me.lucko.spark.common.SparkPlatform;
 import me.lucko.spark.common.SparkPlugin;
+import me.lucko.spark.common.PlatformInfo;
 import me.lucko.spark.common.sampler.ThreadDumper;
 import me.lucko.spark.common.sampler.tick.TickHook;
 import org.spongepowered.api.Game;
@@ -122,6 +123,11 @@ public class SpongeSparkPlugin implements SparkPlugin {
     @Override
     public TickHook createTickHook() {
         return new SpongeTickHook(this);
+    }
+
+    @Override
+    public PlatformInfo getPlatformInfo() {
+        return new SpongePlatformInfo();
     }
 
     private static final class SparkCommand implements CommandCallable {

--- a/spark-velocity/src/main/java/me/lucko/spark/velocity/VelocityPlatformInfo.java
+++ b/spark-velocity/src/main/java/me/lucko/spark/velocity/VelocityPlatformInfo.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.velocity;
+
+import com.velocitypowered.api.proxy.ProxyServer;
+import me.lucko.spark.common.PlatformInfo;
+
+public class VelocityPlatformInfo implements PlatformInfo {
+
+    private final ProxyServer proxy;
+
+    public VelocityPlatformInfo(ProxyServer proxy) {
+        this.proxy = proxy;
+    }
+
+    @Override
+    public Type getType() {
+        return Type.PROXY;
+    }
+
+    @Override
+    public String getName() {
+        return "Velocity";
+    }
+
+    @Override
+    public String getVersion() {
+        return this.proxy.getVersion().getVersion();
+    }
+
+    @Override
+    public String getMinecraftVersion() {
+        return null;
+    }
+}

--- a/spark-velocity/src/main/java/me/lucko/spark/velocity/VelocitySparkPlugin.java
+++ b/spark-velocity/src/main/java/me/lucko/spark/velocity/VelocitySparkPlugin.java
@@ -32,6 +32,7 @@ import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
 import me.lucko.spark.common.SparkPlatform;
 import me.lucko.spark.common.SparkPlugin;
+import me.lucko.spark.common.PlatformInfo;
 import org.checkerframework.checker.optional.qual.MaybePresent;
 
 import java.nio.file.Path;
@@ -106,5 +107,10 @@ public class VelocitySparkPlugin implements SparkPlugin, Command {
     @Override
     public void executeAsync(Runnable task) {
         this.proxy.getScheduler().buildTask(this, task).schedule();
+    }
+
+    @Override
+    public PlatformInfo getPlatformInfo() {
+        return new VelocityPlatformInfo(this.proxy);
     }
 }


### PR DESCRIPTION
Things to consider:
- This hasn't been tested on Sponge - is MC version consistent with other platforms?
- Where should the PlatformInfo class go?
- Should activity logs contain platform info? This is redundant for most users, but could be useful for comparisons between platforms? (Right now JSON methods exist but aren't used)
- Should we add CPU/memory or number of chunks/entities? (suggested by Luck on Discord)
- ~~spark-web and~~ spark-ignition currently don't support platform data, but they shouldn't blow up when this data is sent
  - lucko/spark-web#4 adds support to spark-web

Closes #56.