### PR TITLE
Add PlatformAPI

### DIFF
--- a/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitSparkPlugin.java
+++ b/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitSparkPlugin.java
@@ -23,6 +23,7 @@ package me.lucko.spark.bukkit;
 import me.lucko.spark.bukkit.placeholder.SparkMVdWPlaceholders;
 import me.lucko.spark.bukkit.placeholder.SparkPlaceholderApi;
 import me.lucko.spark.common.SparkPlatform;
+import me.lucko.spark.common.SparkPlatformAPI;
 import me.lucko.spark.common.SparkPlugin;
 import me.lucko.spark.common.platform.PlatformInfo;
 import me.lucko.spark.common.sampler.ThreadDumper;
@@ -42,11 +43,13 @@ public class BukkitSparkPlugin extends JavaPlugin implements SparkPlugin {
 
     private CommandExecutor tpsCommand = null;
     private SparkPlatform platform;
+    private SparkPlatformAPI platformAPI;
 
     @Override
     public void onEnable() {
         this.platform = new SparkPlatform(this);
         this.platform.enable();
+        this.platformAPI = new SparkPlatformAPI(this.platform);
 
         // override Spigot's TPS command with our own.
         if (getConfig().getBoolean("override-tps-command", true)) {
@@ -152,6 +155,11 @@ public class BukkitSparkPlugin extends JavaPlugin implements SparkPlugin {
     @Override
     public PlatformInfo getPlatformInfo() {
         return new BukkitPlatformInfo(getServer());
+    }
+
+    @Override
+    public SparkPlatformAPI getAPI() {
+        return this.platformAPI;
     }
 
     private static boolean classExists(String className) {

--- a/spark-common/src/main/java/me/lucko/spark/common/SparkPlatformAPI.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/SparkPlatformAPI.java
@@ -1,0 +1,34 @@
+package me.lucko.spark.common;
+
+import me.lucko.spark.common.activitylog.ActivityLog;
+import me.lucko.spark.common.monitor.tick.TickStatistics;
+import me.lucko.spark.common.sampler.tick.TickHook;
+import me.lucko.spark.common.sampler.tick.TickReporter;
+
+/**
+ *
+ */
+public class SparkPlatformAPI {
+
+    private final SparkPlatform platform;
+
+    public SparkPlatformAPI(SparkPlatform platform) {
+        this.platform = platform;
+    }
+
+    public ActivityLog getActivityLog() {
+        return this.platform.getActivityLog();
+    }
+
+    public TickHook getTickHook() {
+        return this.platform.getTickHook();
+    }
+
+    public TickReporter getTickReporter() {
+        return this.platform.getTickReporter();
+    }
+
+    public TickStatistics getTickStatistics() {
+        return this.platform.getTickStatistics();
+    }
+}

--- a/spark-common/src/main/java/me/lucko/spark/common/SparkPlugin.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/SparkPlugin.java
@@ -109,4 +109,10 @@ public interface SparkPlugin {
      */
     PlatformInfo getPlatformInfo();
 
+    /**
+     * Gets the API that third party plugins can use to add callbacks to the hooks and reporters
+     * <p>Returns {@code null} if the platform does not have API support yet</p>
+     * @return an API object
+     */
+    default SparkPlatformAPI getAPI() { return null; }
 }


### PR DESCRIPTION
## Summary

Creates an API to expose some parts of the Spark platform to third party plugins that may be interested in registering their own callbacks in the hooks/reporters. Right now there is a callback system but it only contains one callback, which is Spark's internal callbacks. For example, I have another plugin in the works that streams TPS/heap usage data to AWS CloudWatch.

## Policy

The `SparkPlugin` interface now has a `getAPI` method that returns a `SparkPlatformAPI` object. This `SparkPlatformAPI` object can decide what parts of the spark platform to expose.

## Implementation

I am only familiar with Bukkit/Spigot/Paper, so I have only implemented `getAPI` in `BukkitSparkPlugin`. The other platforms will default to the interface's default method that returns null. The other platforms simply needs to instantiate a `SparkPlatformAPI` object in the platform's plugin enable sequence, but I will leave this to other contributors who are more experienced with other platforms like fabric or forge.