### PR TITLE
Add support for Cloudburst Nukkit

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -19,5 +19,6 @@ include (
         'spark-forge',
         'spark-forge1122',
         'spark-fabric',
+        'spark-nukkit',
         'spark-universal'
 )

--- a/spark-nukkit/build.gradle
+++ b/spark-nukkit/build.gradle
@@ -1,0 +1,42 @@
+plugins {
+    id 'com.github.johnrengelman.shadow' version '4.0.1'
+}
+
+dependencies {
+    compile project(':spark-common')
+    compile('net.kyori:adventure-text-serializer-legacy:4.4.0')
+    compileOnly 'cn.nukkit:nukkit:1.0-SNAPSHOT'
+}
+
+repositories {
+    maven { url "https://repo.opencollab.dev/maven-snapshots/" }
+}
+
+processResources {
+    from(sourceSets.main.resources.srcDirs) {
+        expand (
+                'pluginVersion': project.pluginVersion,
+                'pluginDescription': project.pluginDescription
+        )
+        include 'plugin.yml'
+    }
+}
+
+shadowJar {
+    archiveName = 'spark-nukkit.jar'
+
+    relocate 'okio', 'me.lucko.spark.lib.okio'
+    relocate 'okhttp3', 'me.lucko.spark.lib.okhttp3'
+    relocate 'org.tukaani.xz', 'me.lucko.spark.lib.xz'
+    relocate 'com.google.protobuf', 'me.lucko.spark.lib.protobuf'
+    relocate 'org.objectweb.asm', 'me.lucko.spark.lib.asm'
+
+    exclude 'module-info.class'
+    exclude 'META-INF/maven/**'
+    exclude 'META-INF/proguard/**'
+}
+
+artifacts {
+    archives shadowJar
+    shadow shadowJar
+}

--- a/spark-nukkit/src/main/java/me/lucko/spark/nukkit/NukkitCommandSender.java
+++ b/spark-nukkit/src/main/java/me/lucko/spark/nukkit/NukkitCommandSender.java
@@ -1,0 +1,39 @@
+package me.lucko.spark.nukkit;
+
+import cn.nukkit.Player;
+import cn.nukkit.command.CommandSender;
+import me.lucko.spark.common.command.sender.AbstractCommandSender;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+
+import java.util.UUID;
+
+public class NukkitCommandSender extends AbstractCommandSender<CommandSender> {
+
+    public NukkitCommandSender(CommandSender delegate) {
+        super(delegate);
+    }
+
+    @Override
+    public String getName() {
+        return this.delegate.getName();
+    }
+
+    @Override
+    public UUID getUniqueId() {
+        if (this.delegate instanceof Player) {
+            return ((Player) this.delegate).getUniqueId();
+        }
+        return null;
+    }
+
+    @Override
+    public void sendMessage(Component message) {
+        this.delegate.sendMessage(LegacyComponentSerializer.legacySection().serialize(message));
+    }
+
+    @Override
+    public boolean hasPermission(String permission) {
+        return this.delegate.hasPermission(permission);
+    }
+}

--- a/spark-nukkit/src/main/java/me/lucko/spark/nukkit/NukkitPlatformInfo.java
+++ b/spark-nukkit/src/main/java/me/lucko/spark/nukkit/NukkitPlatformInfo.java
@@ -1,0 +1,33 @@
+package me.lucko.spark.nukkit;
+
+import cn.nukkit.Server;
+import cn.nukkit.network.protocol.ProtocolInfo;
+import me.lucko.spark.common.platform.AbstractPlatformInfo;
+
+public class NukkitPlatformInfo extends AbstractPlatformInfo {
+    private final Server server;
+
+    public NukkitPlatformInfo(Server server) {
+        this.server = server;
+    }
+
+    @Override
+    public Type getType() {
+        return Type.SERVER;
+    }
+
+    @Override
+    public String getName() {
+        return "Nukkit";
+    }
+
+    @Override
+    public String getVersion() {
+        return this.server.getVersion();
+    }
+
+    @Override
+    public String getMinecraftVersion() {
+        return ProtocolInfo.MINECRAFT_VERSION;
+    }
+}

--- a/spark-nukkit/src/main/java/me/lucko/spark/nukkit/NukkitPlatformInfo.java
+++ b/spark-nukkit/src/main/java/me/lucko/spark/nukkit/NukkitPlatformInfo.java
@@ -23,11 +23,11 @@ public class NukkitPlatformInfo extends AbstractPlatformInfo {
 
     @Override
     public String getVersion() {
-        return this.server.getVersion();
+        return this.server.getNukkitVersion();
     }
 
     @Override
     public String getMinecraftVersion() {
-        return ProtocolInfo.MINECRAFT_VERSION;
+        return this.server.getVersion();
     }
 }

--- a/spark-nukkit/src/main/java/me/lucko/spark/nukkit/NukkitSparkPlugin.java
+++ b/spark-nukkit/src/main/java/me/lucko/spark/nukkit/NukkitSparkPlugin.java
@@ -1,0 +1,71 @@
+package me.lucko.spark.nukkit;
+
+import cn.nukkit.command.Command;
+import cn.nukkit.command.CommandSender;
+import cn.nukkit.plugin.PluginBase;
+import cn.nukkit.scheduler.AsyncTask;
+import me.lucko.spark.common.SparkPlatform;
+import me.lucko.spark.common.SparkPlugin;
+import me.lucko.spark.common.platform.PlatformInfo;
+
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+public class NukkitSparkPlugin extends PluginBase implements SparkPlugin {
+    private SparkPlatform platform;
+
+    @Override
+    public void onEnable() {
+        this.platform = new SparkPlatform(this);
+        this.platform.enable();
+    }
+
+    @Override
+    public void onDisable() {
+        this.platform.disable();
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        this.platform.executeCommand(new NukkitCommandSender(sender), args);
+        return true;
+    }
+
+    @Override
+    public String getVersion() {
+        return getDescription().getVersion();
+    }
+
+    @Override
+    public Path getPluginDirectory() {
+        return getDataFolder().toPath();
+    }
+
+    @Override
+    public String getCommandName() {
+        return "spark";
+    }
+
+    @Override
+    public Stream<NukkitCommandSender> getSendersWithPermission(String permission) {
+        return Stream.concat(
+                getServer().getOnlinePlayers().values().stream().filter(player -> player.hasPermission(permission)),
+                Stream.of(getServer().getConsoleSender())
+        ).map(NukkitCommandSender::new);
+    }
+
+    @Override
+    public void executeAsync(Runnable task) {
+        getServer().getScheduler().scheduleAsyncTask(this, new AsyncTask() {
+            @Override
+            public void onRun() {
+                task.run();
+            }
+        });
+    }
+
+    @Override
+    public PlatformInfo getPlatformInfo() {
+        return new NukkitPlatformInfo(getServer());
+    }
+}

--- a/spark-nukkit/src/main/resources/plugin.yml
+++ b/spark-nukkit/src/main/resources/plugin.yml
@@ -1,0 +1,9 @@
+name: spark
+version: ${pluginVersion}
+description: ${pluginDescription}
+authors: [Luck, sk89q]
+main: me.lucko.spark.nukkit.NukkitSparkPlugin
+api: [1.0.5]
+commands:
+  spark:
+    description: Main plugin command


### PR DESCRIPTION
This pull request adds support for using spark with the Nukkit server software. I'm also going to add support for it's newer cousin, [Cloudburst Server](https://github.com/CloudburstMC/Server) but I can keep that in my repo if preferred.

### Testing
Tested a bit and it works perfectly.

Output from `spark heapsummary`: https://spark.lucko.me/#fVqRJ8pL8t
Output from `spark healthreport`:
![image](https://user-images.githubusercontent.com/32024335/105644201-1d017800-5e8c-11eb-8aec-7bd0a0188dad.png)

I'm not sure if there is a way to get `spark tickmonitor` working as I see no tick related events.
