### PR TITLE
fix typo in SamplerModule.java

### DIFF
--- a/spark-common/src/main/java/me/lucko/spark/common/command/modules/SamplerModule.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/command/modules/SamplerModule.java
@@ -208,7 +208,7 @@ public class SamplerModule implements CommandModule {
 
                     resp.broadcastPrefixed(text("Profiler now active!", GOLD));
                     if (timeoutSeconds == -1) {
-                        resp.broadcastPrefixed(text("Use '/" + platform.getPlugin().getCommandName() + " sampler --stop' to stop profiling and upload the results."));
+                        resp.broadcastPrefixed(text("Use '/" + platform.getPlugin().getCommandName() + " profiler --stop' to stop profiling and upload the results."));
                     } else {
                         resp.broadcastPrefixed(text("The results will be automatically returned after the profiler has been running for " + timeoutSeconds + " seconds."));
                     }


### PR DESCRIPTION
`sampler --stop` should be `profiler --stop` when this message is printed:
```
Initializing a new profiler, please wait...
Profiler now active!
Use '/spark sampler --stop' to stop profiling and upload the results.
```