### PR TITLE
Port the plugin to sponge 8

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,7 @@ include (
         'spark-bungeecord',
         'spark-velocity',
         'spark-sponge',
+        'spark-sponge8',
         'spark-forge',
         'spark-forge1122',
         'spark-fabric',

--- a/spark-sponge8/build.gradle
+++ b/spark-sponge8/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id("java-library")
+    id('com.github.johnrengelman.shadow') version '4.0.1'
+}
+
+dependencies {
+    compile project(':spark-common')
+    compileOnly "org.spongepowered:spongeapi:8.0.0-SNAPSHOT"
+}
+
+repositories {
+    maven {
+        url "https://repo.spongepowered.org/repository/maven-public/"
+        name "sponge"
+    }
+}
+
+shadowJar {
+    archiveFileName = 'spark-sponge8.jar'
+}
+
+artifacts {
+    archives shadowJar
+    shadow shadowJar
+}
+
+processResources {
+    from(sourceSets.main.resources.srcDirs) {
+        include 'META-INF/plugins.json'
+
+        expand (
+            version: project.version,
+            description: project.pluginDescription
+        )
+    }
+}
+

--- a/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8CommandSender.java
+++ b/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8CommandSender.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package me.lucko.spark.sponge;
+
+import me.lucko.spark.common.command.sender.AbstractCommandSender;
+
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.text.Component;
+import org.spongepowered.api.service.permission.Subject;
+
+
+import java.util.UUID;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class Sponge8CommandSender extends AbstractCommandSender<Audience> {
+    private final Subject subject;
+
+    public Sponge8CommandSender(Subject subject, Audience audience) {
+        super(audience);
+        this.subject = subject;
+    }
+
+    @Override
+    public String getName() {
+        return subject.friendlyIdentifier().orElse(subject.identifier());
+    }
+
+    @Override
+    public UUID getUniqueId() {
+        try {
+            return UUID.fromString(subject.identifier());
+        } catch (Exception e) {
+            return UUID.nameUUIDFromBytes(subject.identifier().getBytes(UTF_8));
+        }
+    }
+
+    @Override
+    public void sendMessage(Component message) {
+        delegate.sendMessage(message);
+    }
+
+    @Override
+    public boolean hasPermission(String permission) {
+        return subject.hasPermission(permission);
+    }
+}

--- a/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8PlatformInfo.java
+++ b/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8PlatformInfo.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.sponge;
+
+import me.lucko.spark.common.platform.AbstractPlatformInfo;
+
+import org.spongepowered.api.Game;
+import org.spongepowered.api.Platform;
+import org.spongepowered.plugin.metadata.PluginMetadata;
+
+public class Sponge8PlatformInfo extends AbstractPlatformInfo {
+    private final Game game;
+
+    public Sponge8PlatformInfo(Game game) {
+        this.game = game;
+    }
+
+    @Override
+    public Type getType() {
+        return Type.SERVER;
+    }
+
+    @Override
+    public String getName() {
+        return getMetadata().getName().orElse(getMetadata().getId());
+    }
+
+    @Override
+    public String getVersion() {
+        return getMetadata().getVersion();
+    }
+
+    private PluginMetadata getMetadata() {
+        return this.game.platform().container(Platform.Component.IMPLEMENTATION).getMetadata();
+    }
+
+    @Override
+    public String getMinecraftVersion() {
+        return this.game.platform().minecraftVersion().name();
+    }
+}

--- a/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8SparkPlugin.java
+++ b/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8SparkPlugin.java
@@ -1,0 +1,190 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.sponge;
+
+import com.google.inject.Inject;
+
+import me.lucko.spark.common.SparkPlatform;
+import me.lucko.spark.common.SparkPlugin;
+import me.lucko.spark.common.command.sender.CommandSender;
+import me.lucko.spark.common.platform.PlatformInfo;
+import me.lucko.spark.common.sampler.ThreadDumper;
+import me.lucko.spark.common.tick.TickHook;
+
+import net.kyori.adventure.text.Component;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.Server;
+import org.spongepowered.api.command.Command;
+import org.spongepowered.api.command.CommandCause;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.exception.CommandException;
+import org.spongepowered.api.command.parameter.ArgumentReader;
+import org.spongepowered.api.command.registrar.tree.CommandTreeNode;
+import org.spongepowered.api.config.ConfigDir;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.lifecycle.RegisterCommandEvent;
+import org.spongepowered.api.event.lifecycle.StartedEngineEvent;
+import org.spongepowered.api.event.lifecycle.StoppingEngineEvent;
+import org.spongepowered.plugin.PluginContainer;
+import org.spongepowered.plugin.jvm.Plugin;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Stream;
+
+@Plugin("spark")
+public class Sponge8SparkPlugin implements SparkPlugin {
+
+    private final PluginContainer pluginContainer;
+    private final Game game;
+    private final Path configDirectory;
+    private final ExecutorService asyncExecutor;
+
+    private SparkPlatform platform;
+    private final ThreadDumper.GameThread threadDumper = new ThreadDumper.GameThread();
+
+    @Inject
+    public Sponge8SparkPlugin(PluginContainer pluginContainer, Game game, @ConfigDir(sharedRoot = false) Path configDirectory) {
+
+        this.pluginContainer = pluginContainer;
+        this.game = game;
+        this.configDirectory = configDirectory;
+        this.asyncExecutor = game.asyncScheduler().createExecutor(pluginContainer);
+    }
+
+
+    @Listener
+    public void onRegisterCommands(final RegisterCommandEvent<Command.Raw> event) {
+        event.register(this.pluginContainer, new SparkCommand(this), pluginContainer.getMetadata().getId());
+    }
+
+    @Listener
+    public void onEnable(StartedEngineEvent<Server> event) {
+        this.platform = new SparkPlatform(this);
+        this.platform.enable();
+    }
+
+    @Listener
+    public void onDisable(StoppingEngineEvent<Server> event) {
+        this.platform.disable();
+    }
+
+    @Override
+    public String getVersion() {
+        return this.pluginContainer.getMetadata().getVersion();
+    }
+
+    @Override
+    public Path getPluginDirectory() {
+        return this.configDirectory;
+    }
+
+    @Override
+    public String getCommandName() {
+        return "spark";
+    }
+
+    @Override
+    public Stream<CommandSender> getCommandSenders() {
+        return Stream.concat(
+                this.game.server().onlinePlayers().stream(),
+                Stream.of(this.game.systemSubject())
+        ).map(s -> new Sponge8CommandSender(s, s));
+    }
+
+    @Override
+    public void executeAsync(Runnable task) {
+        this.asyncExecutor.execute(task);
+    }
+
+    @Override
+    public ThreadDumper getDefaultThreadDumper() {
+        return this.threadDumper.get();
+    }
+
+    @Override
+    public TickHook createTickHook() {
+        return new Sponge8TickHook(this.pluginContainer, this.game);
+    }
+
+    @Override
+    public PlatformInfo getPlatformInfo() {
+        return new Sponge8PlatformInfo(this.game);
+    }
+
+    private static final class SparkCommand implements Command.Raw {
+
+        private Sponge8SparkPlugin plugin;
+
+        public SparkCommand(Sponge8SparkPlugin plugin) {
+            this.plugin = plugin;
+        }
+
+        @Override
+        public CommandResult process(CommandCause cause, ArgumentReader.Mutable arguments) {
+            this.plugin.threadDumper.ensureSetup();
+            this.plugin.platform.executeCommand(getSenderFromCause(cause), arguments.input().split(" "));
+            return CommandResult.empty();
+        }
+
+        @Override
+        public List<String> suggestions(CommandCause cause, ArgumentReader.Mutable arguments) {
+            return this.plugin.platform.tabCompleteCommand(getSenderFromCause(cause), arguments.input().split(" "));
+        }
+
+        private static CommandSender getSenderFromCause(CommandCause cause) {
+            return new Sponge8CommandSender(cause.subject(), cause.audience());
+        }
+
+        @Override
+        public boolean canExecute(CommandCause cause) {
+            return this.plugin.platform.hasPermissionForAnyCommand(getSenderFromCause(cause));
+        }
+
+        @Override
+        public Optional<Component> shortDescription(CommandCause cause) {
+            return Optional.of(Component.text("Main spark plugin command"));
+        }
+
+        @Override
+        public Optional<Component> extendedDescription(CommandCause cause) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Component usage(CommandCause cause) {
+            return Component.text("Run '/spark' to view usage.");
+        }
+
+        @Override
+        public CommandTreeNode.Root commandTree() {
+            return Command.Raw.super.commandTree();
+        }
+
+        @Override
+        public Optional<Component> help(@NonNull CommandCause cause) {
+            return Optional.of(Component.text("Run '/spark' to view usage."));
+        }
+    }
+}

--- a/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8TickHook.java
+++ b/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8TickHook.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.sponge;
+
+import me.lucko.spark.common.tick.AbstractTickHook;
+import me.lucko.spark.common.tick.TickHook;
+
+import org.spongepowered.api.Game;
+import org.spongepowered.api.scheduler.ScheduledTask;
+import org.spongepowered.api.scheduler.Task;
+import org.spongepowered.api.util.Ticks;
+import org.spongepowered.plugin.PluginContainer;
+
+public class Sponge8TickHook extends AbstractTickHook implements TickHook, Runnable {
+    private final PluginContainer plugin;
+    private final Game game;
+    private ScheduledTask task;
+
+    public Sponge8TickHook(PluginContainer plugin, Game game) {
+        this.plugin = plugin;
+        this.game = game;
+    }
+
+    @Override
+    public void run() {
+        onTick();
+    }
+
+    @Override
+    public void start() {
+        Task task = Task.builder()
+                .interval(Ticks.of(1))
+                .name("spark-ticker")
+                .plugin(plugin)
+                .execute(this)
+                .build();
+        this.task = game.server().scheduler().submit(task);
+    }
+
+    @Override
+    public void close() {
+        this.task.cancel();
+    }
+
+}

--- a/spark-sponge8/src/main/resources/META-INF/plugins.json
+++ b/spark-sponge8/src/main/resources/META-INF/plugins.json
@@ -1,0 +1,31 @@
+{
+    "plugins": [
+        {
+            "loader": "java_plain",
+            "id": "spark",
+            "name": "spark-sponge8",
+            "version": "${version}",
+            "main-class": "me.lucko.spark.sponge.Sponge8SparkPlugin",
+            "description": "${description}",
+            "links": {
+                "homepage": "https://spark.lucko.me/",
+                "source": "https://github.com/lucko/spark",
+                "issues": "https://github.com/lucko/spark/issues"
+            },
+            "contributors": [
+                {
+                    "name": "Luck",
+                    "description": "Lead Developer"
+                }
+            ],
+            "dependencies": [
+                {
+                    "id": "spongeapi",
+                    "version": "8.0.0",
+                    "load-order": "AFTER",
+                    "optional": false
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
We (@Faithcaio and I) simply copied the sponge 7 module and converted it over to sponge 8.

In order to work with the SpongeVanilla gradle plugin we had to raise the gradle version to 6.8, which is incompatible with Forge. In principle it should also be doable with the blossom plugin without raising the gradle requirement.

The sponge8 is not included in the universal module, but instead applies shadow itself.

Feedback is very welcome!