### PR TITLE
Fixed Sponge 8 refusing to compile due to removal of get prefixes on plugin metadata

### DIFF
--- a/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8PlatformInfo.java
+++ b/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8PlatformInfo.java
@@ -44,7 +44,7 @@ public class Sponge8PlatformInfo extends AbstractPlatformInfo {
 
     @Override
     public String getVersion() {
-        return this.game.platform().container(Platform.Component.IMPLEMENTATION).getMetadata().getVersion();
+        return this.game.platform().container(Platform.Component.IMPLEMENTATION).metadata().version();
     }
 
     @Override

--- a/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8SparkPlugin.java
+++ b/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8SparkPlugin.java
@@ -75,7 +75,7 @@ public class Sponge8SparkPlugin implements SparkPlugin {
 
     @Listener
     public void onRegisterCommands(final RegisterCommandEvent<Command.Raw> event) {
-        event.register(this.pluginContainer, new SparkCommand(this), this.pluginContainer.getMetadata().getId());
+        event.register(this.pluginContainer, new SparkCommand(this), this.pluginContainer.metadata().id());
     }
 
     @Listener
@@ -91,7 +91,7 @@ public class Sponge8SparkPlugin implements SparkPlugin {
 
     @Override
     public String getVersion() {
-        return this.pluginContainer.getMetadata().getVersion();
+        return this.pluginContainer.metadata().version();
     }
 
     @Override


### PR DESCRIPTION
Does what it says in the title. I'm going to guess that Sponge 8 support was added before they made this change.