### PR TITLE
Expose a Profiler API in `spark-api`

### DIFF
--- a/spark-api/build.gradle
+++ b/spark-api/build.gradle
@@ -5,8 +5,8 @@ plugins {
 version = '0.1-SNAPSHOT'
 
 dependencies {
-    compileOnly 'org.checkerframework:checker-qual:3.8.0'
-    compileOnly 'org.jetbrains:annotations:20.1.0'
+    compileOnly 'org.checkerframework:checker-qual:3.16.0'
+    compileOnly 'org.jetbrains:annotations:22.0.0'
 }
 
 publishing {

--- a/spark-api/src/main/java/me/lucko/spark/api/Spark.java
+++ b/spark-api/src/main/java/me/lucko/spark/api/Spark.java
@@ -26,11 +26,11 @@
 package me.lucko.spark.api;
 
 import me.lucko.spark.api.gc.GarbageCollector;
+import me.lucko.spark.api.profiler.Profiler;
 import me.lucko.spark.api.statistic.StatisticWindow;
 import me.lucko.spark.api.statistic.misc.DoubleAverageInfo;
 import me.lucko.spark.api.statistic.types.DoubleStatistic;
 import me.lucko.spark.api.statistic.types.GenericStatistic;
-
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
@@ -81,4 +81,10 @@ public interface Spark {
      */
     @NonNull @Unmodifiable Map<String, GarbageCollector> gc();
 
+    /**
+     * Get the {@link Profiler} API.
+     *
+     * @return the profiler api
+     */
+    @NonNull Profiler profiler();
 }

--- a/spark-api/src/main/java/me/lucko/spark/api/profiler/Dumper.java
+++ b/spark-api/src/main/java/me/lucko/spark/api/profiler/Dumper.java
@@ -1,0 +1,62 @@
+package me.lucko.spark.api.profiler;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * TODO: implement this class, see {@link ProfilerConfiguration} for the purpose.
+ */
+public final class Dumper {
+    private final Method method;
+    private final Set<String> criteria;
+
+    /**
+     *
+     */
+    public Dumper(Method method, Set<String> criteria) {
+        this.method = method;
+        this.criteria = criteria;
+    }
+
+    public static Dumper pattern(Set<String> criteria) {
+        return new Dumper(Method.PATTERN, criteria);
+    }
+
+    public static Dumper specific(Set<String> criteria) {
+        return new Dumper(Method.SPECIFIC, criteria);
+    }
+
+    public Method method() {
+        return method;
+    }
+
+    public Set<String> criteria() {
+        return criteria;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        Dumper that = (Dumper) obj;
+        return Objects.equals(this.method, that.method) &&
+                Objects.equals(this.criteria, that.criteria);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(method, criteria);
+    }
+
+    @Override
+    public String toString() {
+        return "Dumper[" +
+                "method=" + method + ", " +
+                "criteria=" + criteria + ']';
+    }
+
+    public enum Method {
+        PATTERN,
+        SPECIFIC
+    }
+}

--- a/spark-api/src/main/java/me/lucko/spark/api/profiler/DumperChoice.java
+++ b/spark-api/src/main/java/me/lucko/spark/api/profiler/DumperChoice.java
@@ -1,0 +1,4 @@
+package me.lucko.spark.api.profiler;
+
+public final class DumperChoice {
+}

--- a/spark-api/src/main/java/me/lucko/spark/api/profiler/DumperChoice.java
+++ b/spark-api/src/main/java/me/lucko/spark/api/profiler/DumperChoice.java
@@ -1,4 +1,7 @@
 package me.lucko.spark.api.profiler;
 
+/**
+ * TODO: implement this class, see {@link ProfilerConfiguration} for the purpose.
+ */
 public final class DumperChoice {
 }

--- a/spark-api/src/main/java/me/lucko/spark/api/profiler/DumperChoice.java
+++ b/spark-api/src/main/java/me/lucko/spark/api/profiler/DumperChoice.java
@@ -1,7 +1,0 @@
-package me.lucko.spark.api.profiler;
-
-/**
- * TODO: implement this class, see {@link ProfilerConfiguration} for the purpose.
- */
-public final class DumperChoice {
-}

--- a/spark-api/src/main/java/me/lucko/spark/api/profiler/GrouperChoice.java
+++ b/spark-api/src/main/java/me/lucko/spark/api/profiler/GrouperChoice.java
@@ -1,0 +1,10 @@
+package me.lucko.spark.api.profiler;
+
+/**
+ * Group the threads by a specific mode. Either grouping them by name, pool or combined into a single group.
+ */
+public enum GrouperChoice {
+    SINGLE,
+    NAME,
+    POOL
+}

--- a/spark-api/src/main/java/me/lucko/spark/api/profiler/Profiler.java
+++ b/spark-api/src/main/java/me/lucko/spark/api/profiler/Profiler.java
@@ -1,0 +1,8 @@
+package me.lucko.spark.api.profiler;
+
+public interface Profiler {
+
+    boolean start(ProfilerConfiguration configuration);
+
+    ProfilerReport stop();
+}

--- a/spark-api/src/main/java/me/lucko/spark/api/profiler/Profiler.java
+++ b/spark-api/src/main/java/me/lucko/spark/api/profiler/Profiler.java
@@ -1,8 +1,23 @@
 package me.lucko.spark.api.profiler;
 
+import org.jetbrains.annotations.Nullable;
+
 public interface Profiler {
 
+    /**
+     * Start the Spark Profiler using a profiler configuration.
+     * A configuration can be built using {@link ProfilerConfiguration#builder()}.
+     *
+     * @param configuration the configuration object
+     * @return if the profiler started successfully
+     */
     boolean start(ProfilerConfiguration configuration);
 
+    /**
+     * Stop the currently running profiler.
+     *
+     * @return the profiler report or null if no profiler was running.
+     */
+    @Nullable
     ProfilerReport stop();
 }

--- a/spark-api/src/main/java/me/lucko/spark/api/profiler/ProfilerConfiguration.java
+++ b/spark-api/src/main/java/me/lucko/spark/api/profiler/ProfilerConfiguration.java
@@ -1,0 +1,73 @@
+package me.lucko.spark.api.profiler;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Duration;
+
+public interface ProfilerConfiguration {
+
+    static ProfilerConfigurationBuilder builder() {
+        return new ProfilerConfigurationBuilder();
+    }
+
+    /**
+     * Get the interval (in millis) of when the profiler should take samples.
+     *
+     * @return the sample interval
+     */
+    double interval();
+
+    /**
+     * Get if sleeping threads should be ignored.
+     *
+     * @return if sleeping threads are ignored
+     */
+    boolean ignoreSleeping();
+
+    /**
+     * Get if native threads should be ignored.
+     *
+     * @return if native threads are ignored
+     */
+    boolean ignoreNative();
+
+    /**
+     * Get if the native Java sampler should be used.
+     *
+     * @return if the native Java sampler is used
+     */
+    boolean forceJavaSampler();
+
+    /**
+     * Minimum duration (in millis) a tick has to take in order to be recorded.
+     *
+     * @return the minimum tick duration
+     */
+    int minimumTickDuration();
+
+    /**
+     * Get how long the profiler should run, if the duration is null, the profiler runs indefinite.
+     *
+     * @return duration of the profile or null if indefinite
+     */
+    @Nullable
+    Duration duration();
+
+    /**
+     * Get the choice of which dumper to use (i.e. ALL, Regex or Specific).
+     * If no dumper is defined, ALL is used.
+     *
+     * @return the thread dumper choice
+     */
+    @Nullable
+    DumperChoice dumper();
+
+    /**
+     * Get the choice of which thread grouper (AS_ONE, BY_NAME, BY_POOL) to use for this profiler.
+     * If the grouper is null, BY_POOL is used.
+     *
+     * @return the thread grouper choice
+     */
+    @Nullable
+    GrouperChoice grouper();
+}

--- a/spark-api/src/main/java/me/lucko/spark/api/profiler/ProfilerConfiguration.java
+++ b/spark-api/src/main/java/me/lucko/spark/api/profiler/ProfilerConfiguration.java
@@ -40,6 +40,7 @@ public interface ProfilerConfiguration {
 
     /**
      * Minimum duration (in millis) a tick has to take in order to be recorded.
+     * If this value is below 0, all ticks will be recorded.
      *
      * @return the minimum tick duration
      */
@@ -60,7 +61,7 @@ public interface ProfilerConfiguration {
      * @return the thread dumper choice
      */
     @Nullable
-    DumperChoice dumper();
+    Dumper dumper();
 
     /**
      * Get the choice of which thread grouper (AS_ONE, BY_NAME, BY_POOL) to use for this profiler.

--- a/spark-api/src/main/java/me/lucko/spark/api/profiler/ProfilerConfigurationBuilder.java
+++ b/spark-api/src/main/java/me/lucko/spark/api/profiler/ProfilerConfigurationBuilder.java
@@ -1,0 +1,101 @@
+package me.lucko.spark.api.profiler;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Duration;
+
+public class ProfilerConfigurationBuilder {
+
+    private double interval = 5;
+    private boolean ignoreSleeping = false;
+    private boolean ignoreNative = false;
+    private boolean forceJavaSampler = true;
+    private int minimumTickDuration = -1;
+    private @Nullable Duration duration = null;
+    private @Nullable DumperChoice dumper = null;
+    private @Nullable GrouperChoice grouper = null;
+
+    public ProfilerConfigurationBuilder interval(double interval) {
+        this.interval = interval;
+        return this;
+    }
+
+    public ProfilerConfigurationBuilder ignoreSleeping(boolean ignoreSleeping) {
+        this.ignoreSleeping = ignoreSleeping;
+        return this;
+    }
+
+    public ProfilerConfigurationBuilder ignoreNative(boolean ignoreNative) {
+        this.ignoreNative = ignoreNative;
+        return this;
+    }
+
+    public ProfilerConfigurationBuilder forceJavaSampler(boolean forceJavaSampler) {
+        this.forceJavaSampler = forceJavaSampler;
+        return this;
+    }
+
+    public ProfilerConfigurationBuilder minimumTickDuration(int minimumTickDuration) {
+        this.minimumTickDuration = minimumTickDuration;
+        return this;
+    }
+
+    public ProfilerConfigurationBuilder duration(Duration duration) {
+        this.duration = duration;
+        return this;
+    }
+
+    public ProfilerConfigurationBuilder dumper(DumperChoice dumper) {
+        this.dumper = dumper;
+        return this;
+    }
+
+    public ProfilerConfigurationBuilder grouper(GrouperChoice grouper) {
+        this.grouper = grouper;
+        return this;
+    }
+
+    public ProfilerConfiguration build() {
+        return new ProfilerConfiguration() {
+            @Override
+            public double interval() {
+                return interval;
+            }
+
+            @Override
+            public boolean ignoreSleeping() {
+                return ignoreSleeping;
+            }
+
+            @Override
+            public boolean ignoreNative() {
+                return ignoreNative;
+            }
+
+            @Override
+            public boolean forceJavaSampler() {
+                return forceJavaSampler;
+            }
+
+            @Override
+            public int minimumTickDuration() {
+                return minimumTickDuration;
+            }
+
+            @Override
+            public @Nullable Duration duration() {
+                return duration;
+            }
+
+            @Override
+            public @Nullable DumperChoice dumper() {
+                return dumper;
+            }
+
+            @Override
+            public @Nullable GrouperChoice grouper() {
+                return grouper;
+            }
+        };
+    }
+}

--- a/spark-api/src/main/java/me/lucko/spark/api/profiler/ProfilerConfigurationBuilder.java
+++ b/spark-api/src/main/java/me/lucko/spark/api/profiler/ProfilerConfigurationBuilder.java
@@ -12,11 +12,17 @@ public class ProfilerConfigurationBuilder {
     private boolean forceJavaSampler = true;
     private int minimumTickDuration = -1;
     private @Nullable Duration duration = null;
-    private @Nullable DumperChoice dumper = null;
+    private @Nullable Dumper dumper = null;
     private @Nullable GrouperChoice grouper = null;
 
+    /**
+     * Set the interval to a given value or 5 if value is below 0.
+     *
+     * @param interval the interval
+     * @return the builder instance
+     */
     public ProfilerConfigurationBuilder interval(double interval) {
-        this.interval = interval;
+        this.interval = interval > 0 ? interval : 5;
         return this;
     }
 
@@ -35,6 +41,13 @@ public class ProfilerConfigurationBuilder {
         return this;
     }
 
+    /**
+     * Set the minimum tick duration that will be profiled.
+     * If the minimumTickDuration is lower than 0 (default is -1), all ticks will be recorded.
+     *
+     * @param minimumTickDuration the minimum tick duration
+     * @return the builder instance
+     */
     public ProfilerConfigurationBuilder minimumTickDuration(int minimumTickDuration) {
         this.minimumTickDuration = minimumTickDuration;
         return this;
@@ -45,7 +58,7 @@ public class ProfilerConfigurationBuilder {
         return this;
     }
 
-    public ProfilerConfigurationBuilder dumper(DumperChoice dumper) {
+    public ProfilerConfigurationBuilder dumper(Dumper dumper) {
         this.dumper = dumper;
         return this;
     }
@@ -88,7 +101,7 @@ public class ProfilerConfigurationBuilder {
             }
 
             @Override
-            public @Nullable DumperChoice dumper() {
+            public @Nullable Dumper dumper() {
                 return dumper;
             }
 

--- a/spark-api/src/main/java/me/lucko/spark/api/profiler/ProfilerReport.java
+++ b/spark-api/src/main/java/me/lucko/spark/api/profiler/ProfilerReport.java
@@ -1,4 +1,6 @@
 package me.lucko.spark.api.profiler;
 
 public interface ProfilerReport {
+
+    String viewer();
 }

--- a/spark-api/src/main/java/me/lucko/spark/api/profiler/ProfilerReport.java
+++ b/spark-api/src/main/java/me/lucko/spark/api/profiler/ProfilerReport.java
@@ -1,0 +1,4 @@
+package me.lucko.spark.api.profiler;
+
+public interface ProfilerReport {
+}

--- a/spark-common/build.gradle
+++ b/spark-common/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     compileOnly 'com.google.code.gson:gson:2.7'
     compileOnly 'com.google.guava:guava:19.0'
     compileOnly 'org.checkerframework:checker-qual:3.8.0'
+    compileOnly 'org.jetbrains:annotations:22.0.0'
 }
 
 processResources {

--- a/spark-common/src/main/java/me/lucko/spark/common/api/SparkApi.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/api/SparkApi.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import me.lucko.spark.api.Spark;
 import me.lucko.spark.api.SparkProvider;
 import me.lucko.spark.api.gc.GarbageCollector;
+import me.lucko.spark.api.profiler.Profiler;
 import me.lucko.spark.api.statistic.misc.DoubleAverageInfo;
 import me.lucko.spark.api.statistic.types.DoubleStatistic;
 import me.lucko.spark.api.statistic.types.GenericStatistic;
@@ -37,9 +38,7 @@ import me.lucko.spark.common.monitor.tick.TickStatistics;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.sql.Ref;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -169,6 +168,11 @@ public class SparkApi implements Spark {
             map.put(entry.getKey(), new GarbageCollectorInfo(entry.getKey(), entry.getValue(), serverUptime));
         }
         return ImmutableMap.copyOf(map);
+    }
+
+    @Override
+    public @NonNull Profiler profiler() {
+        return null;
     }
 
     public static void register(Spark spark) {

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/SamplerBuilder.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/SamplerBuilder.java
@@ -22,6 +22,7 @@ package me.lucko.spark.common.sampler;
 
 import me.lucko.spark.common.sampler.async.AsyncProfilerAccess;
 import me.lucko.spark.common.sampler.async.AsyncSampler;
+import me.lucko.spark.common.sampler.dumper.PatternThreadDumper;
 import me.lucko.spark.common.sampler.java.JavaSampler;
 import me.lucko.spark.common.tick.TickHook;
 
@@ -95,7 +96,7 @@ public class SamplerBuilder {
 
         int intervalMicros = (int) (this.samplingInterval * 1000d);
         if (this.ticksOver == -1 || this.tickHook == null) {
-            if (this.useAsyncProfiler && this.timeout == -1 && !(this.threadDumper instanceof ThreadDumper.Regex) && AsyncProfilerAccess.INSTANCE.isSupported()) {
+            if (this.useAsyncProfiler && this.timeout == -1 && !(this.threadDumper instanceof PatternThreadDumper) && AsyncProfilerAccess.INSTANCE.isSupported()) {
                 sampler = new AsyncSampler(intervalMicros, this.threadDumper, this.threadGrouper);
             } else {
                 sampler = new JavaSampler(intervalMicros, this.threadDumper, this.threadGrouper, this.timeout, this.ignoreSleeping, this.ignoreNative);

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/SamplerService.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/SamplerService.java
@@ -1,0 +1,83 @@
+package me.lucko.spark.common.sampler;
+
+import me.lucko.spark.api.profiler.Dumper;
+import me.lucko.spark.api.profiler.Profiler;
+import me.lucko.spark.api.profiler.ProfilerConfiguration;
+import me.lucko.spark.api.profiler.ProfilerReport;
+import me.lucko.spark.common.SparkPlatform;
+import me.lucko.spark.common.sampler.dumper.PatternThreadDumper;
+import me.lucko.spark.common.sampler.dumper.SpecificThreadDumper;
+import me.lucko.spark.common.tick.TickHook;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Duration;
+import java.util.Set;
+
+public class SamplerService implements Profiler {
+
+    public static final int MINIMUM_DURATION = 10;
+    public static final String THREAD_WILDCARD = "*";
+
+    private final SparkPlatform platform;
+
+    private Sampler active = null;
+
+    public SamplerService(SparkPlatform platform) {
+        this.platform = platform;
+    }
+
+    @Override
+    public boolean start(ProfilerConfiguration configuration) {
+        if (active != null) {
+            return false;
+        }
+
+        Duration duration = configuration.duration();
+        if (duration != null && duration.getSeconds() <= MINIMUM_DURATION) {
+            return false;
+        }
+
+        double interval = configuration.interval();
+        if (interval <= 0) {
+            return false;
+        }
+
+        ThreadDumper dumper = getThreadDumper(configuration.dumper());
+        ThreadGrouper grouper = ThreadGrouper.get(configuration.grouper());
+
+        int minimum = configuration.minimumTickDuration();
+        if (minimum >= 0) {
+            TickHook hook = platform.getTickHook();
+            if (hook == null) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public @Nullable ProfilerReport stop() {
+        return null;
+    }
+
+    @NotNull
+    private ThreadDumper getThreadDumper(@Nullable Dumper dumper) {
+        if (dumper == null) {
+            return platform.getPlugin().getDefaultThreadDumper();
+        }
+
+        Set<String> criteria = dumper.criteria();
+        if (criteria.contains(THREAD_WILDCARD)) {
+            return ThreadDumper.ALL;
+        }
+
+        Dumper.Method method = dumper.method();
+        if (Dumper.Method.PATTERN.equals(method)) {
+            return new PatternThreadDumper(criteria);
+        }
+
+        return new SpecificThreadDumper(criteria);
+    }
+}

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/ThreadDumper.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/ThreadDumper.java
@@ -21,39 +21,19 @@
 
 package me.lucko.spark.common.sampler;
 
-import me.lucko.spark.common.util.ThreadFinder;
+import me.lucko.spark.common.sampler.dumper.SpecificThreadDumper;
 import me.lucko.spark.proto.SparkProtos.SamplerMetadata;
 
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
-import java.util.stream.Collectors;
 
 /**
  * Uses the {@link ThreadMXBean} to generate {@link ThreadInfo} instances for the threads being
  * sampled.
  */
 public interface ThreadDumper {
-
-    /**
-     * Generates {@link ThreadInfo} data for the sampled threads.
-     *
-     * @param threadBean the thread bean instance to obtain the data from
-     * @return an array of generated thread info instances
-     */
-    ThreadInfo[] dumpThreads(ThreadMXBean threadBean);
-
-    /**
-     * Gets metadata about the thread dumper instance.
-     */
-    SamplerMetadata.ThreadDumper getMetadata();
 
     /**
      * Implementation of {@link ThreadDumper} that generates data for all threads.
@@ -73,11 +53,24 @@ public interface ThreadDumper {
     };
 
     /**
+     * Generates {@link ThreadInfo} data for the sampled threads.
+     *
+     * @param threadBean the thread bean instance to obtain the data from
+     * @return an array of generated thread info instances
+     */
+    ThreadInfo[] dumpThreads(ThreadMXBean threadBean);
+
+    /**
+     * Gets metadata about the thread dumper instance.
+     */
+    SamplerMetadata.ThreadDumper getMetadata();
+
+    /**
      * Utility to cache the creation of a {@link ThreadDumper} targeting
      * the game (server/client) thread.
      */
     final class GameThread implements Supplier<ThreadDumper> {
-        private Specific dumper = null;
+        private ThreadDumper dumper = null;
 
         @Override
         public ThreadDumper get() {
@@ -86,115 +79,8 @@ public interface ThreadDumper {
 
         public void ensureSetup() {
             if (this.dumper == null) {
-                this.dumper = new Specific(new long[]{Thread.currentThread().getId()});
+                this.dumper = new SpecificThreadDumper(new long[]{Thread.currentThread().getId()});
             }
         }
     }
-
-    /**
-     * Implementation of {@link ThreadDumper} that generates data for a specific set of threads.
-     */
-    final class Specific implements ThreadDumper {
-        private final long[] ids;
-        private Set<Thread> threads;
-        private Set<String> threadNamesLowerCase;
-
-        public Specific(long[] ids) {
-            this.ids = ids;
-        }
-
-        public Specific(Set<String> names) {
-            this.threadNamesLowerCase = names.stream().map(String::toLowerCase).collect(Collectors.toSet());
-            this.ids = new ThreadFinder().getThreads()
-                    .filter(t -> this.threadNamesLowerCase.contains(t.getName().toLowerCase()))
-                    .mapToLong(Thread::getId)
-                    .toArray();
-            Arrays.sort(this.ids);
-        }
-
-        public Set<Thread> getThreads() {
-            if (this.threads == null) {
-                this.threads = new ThreadFinder().getThreads()
-                        .filter(t -> Arrays.binarySearch(this.ids, t.getId()) >= 0)
-                        .collect(Collectors.toSet());
-            }
-            return this.threads;
-        }
-
-        public Set<String> getThreadNames() {
-            if (this.threadNamesLowerCase == null) {
-                this.threadNamesLowerCase = getThreads().stream()
-                        .map(t -> t.getName().toLowerCase())
-                        .collect(Collectors.toSet());
-            }
-            return this.threadNamesLowerCase;
-        }
-
-        @Override
-        public ThreadInfo[] dumpThreads(ThreadMXBean threadBean) {
-            return threadBean.getThreadInfo(this.ids, Integer.MAX_VALUE);
-        }
-
-        @Override
-        public SamplerMetadata.ThreadDumper getMetadata() {
-            return SamplerMetadata.ThreadDumper.newBuilder()
-                    .setType(SamplerMetadata.ThreadDumper.Type.SPECIFIC)
-                    .addAllIds(Arrays.stream(this.ids).boxed().collect(Collectors.toList()))
-                    .build();
-        }
-    }
-
-    /**
-     * Implementation of {@link ThreadDumper} that generates data for a regex matched set of threads.
-     */
-    final class Regex implements ThreadDumper {
-        private final ThreadFinder threadFinder = new ThreadFinder();
-        private final Set<Pattern> namePatterns;
-        private final Map<Long, Boolean> cache = new HashMap<>();
-
-        public Regex(Set<String> namePatterns) {
-            this.namePatterns = namePatterns.stream()
-                    .map(regex -> {
-                        try {
-                            return Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
-                        } catch (PatternSyntaxException e) {
-                            return null;
-                        }
-                    })
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toSet());
-        }
-
-        @Override
-        public ThreadInfo[] dumpThreads(ThreadMXBean threadBean) {
-            return this.threadFinder.getThreads()
-                    .filter(thread -> {
-                        Boolean result = this.cache.get(thread.getId());
-                        if (result != null) {
-                            return result;
-                        }
-
-                        for (Pattern pattern : this.namePatterns) {
-                            if (pattern.matcher(thread.getName()).matches()) {
-                                this.cache.put(thread.getId(), true);
-                                return true;
-                            }
-                        }
-                        this.cache.put(thread.getId(), false);
-                        return false;
-                    })
-                    .map(thread -> threadBean.getThreadInfo(thread.getId(), Integer.MAX_VALUE))
-                    .filter(Objects::nonNull)
-                    .toArray(ThreadInfo[]::new);
-        }
-
-        @Override
-        public SamplerMetadata.ThreadDumper getMetadata() {
-            return SamplerMetadata.ThreadDumper.newBuilder()
-                    .setType(SamplerMetadata.ThreadDumper.Type.REGEX)
-                    .addAllPatterns(this.namePatterns.stream().map(Pattern::pattern).collect(Collectors.toList()))
-                    .build();
-        }
-    }
-
 }

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/ThreadGrouper.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/ThreadGrouper.java
@@ -25,6 +25,7 @@ import me.lucko.spark.common.sampler.grouper.NameThreadGrouper;
 import me.lucko.spark.common.sampler.grouper.PoolThreadGrouper;
 import me.lucko.spark.common.sampler.grouper.SingleThreadGrouper;
 import me.lucko.spark.proto.SparkProtos.SamplerMetadata;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Function for grouping threads together
@@ -35,7 +36,10 @@ public interface ThreadGrouper {
     ThreadGrouper BY_POOL = new PoolThreadGrouper();
     ThreadGrouper AS_ONE = new SingleThreadGrouper();
 
-    static ThreadGrouper get(GrouperChoice choice) {
+    static ThreadGrouper get(@Nullable GrouperChoice choice) {
+        if (choice == null) {
+            return BY_POOL;
+        }
         switch (choice) {
             case SINGLE:
                 return AS_ONE;

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/async/AsyncSampler.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/async/AsyncSampler.java
@@ -26,6 +26,7 @@ import me.lucko.spark.common.sampler.Sampler;
 import me.lucko.spark.common.sampler.ThreadDumper;
 import me.lucko.spark.common.sampler.ThreadGrouper;
 import me.lucko.spark.common.sampler.async.jfr.JfrReader;
+import me.lucko.spark.common.sampler.dumper.SpecificThreadDumper;
 import me.lucko.spark.common.sampler.node.MergeMode;
 import me.lucko.spark.common.sampler.node.ThreadNode;
 import me.lucko.spark.common.util.ClassSourceLookup;
@@ -119,7 +120,7 @@ public class AsyncSampler implements Sampler {
         }
 
         String command = "start,event=cpu,interval=" + this.interval + "us,threads,jfr,file=" + this.outputFile.toString();
-        if (this.threadDumper instanceof ThreadDumper.Specific) {
+        if (this.threadDumper instanceof SpecificThreadDumper) {
             command += ",filter";
         }
 
@@ -128,8 +129,8 @@ public class AsyncSampler implements Sampler {
             throw new RuntimeException("Unexpected response: " + resp);
         }
 
-        if (this.threadDumper instanceof ThreadDumper.Specific) {
-            ThreadDumper.Specific threadDumper = (ThreadDumper.Specific) this.threadDumper;
+        if (this.threadDumper instanceof SpecificThreadDumper) {
+            SpecificThreadDumper threadDumper = (SpecificThreadDumper) this.threadDumper;
             for (Thread thread : threadDumper.getThreads()) {
                 this.profiler.addThread(thread);
             }
@@ -187,8 +188,8 @@ public class AsyncSampler implements Sampler {
         this.outputComplete = true;
 
         Predicate<String> threadFilter;
-        if (this.threadDumper instanceof ThreadDumper.Specific) {
-            ThreadDumper.Specific threadDumper = (ThreadDumper.Specific) this.threadDumper;
+        if (this.threadDumper instanceof SpecificThreadDumper) {
+            SpecificThreadDumper threadDumper = (SpecificThreadDumper) this.threadDumper;
             threadFilter = n -> threadDumper.getThreadNames().contains(n.toLowerCase());
         } else {
             threadFilter = n -> true;

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/dumper/PatternThreadDumper.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/dumper/PatternThreadDumper.java
@@ -1,0 +1,69 @@
+package me.lucko.spark.common.sampler.dumper;
+
+import me.lucko.spark.common.sampler.ThreadDumper;
+import me.lucko.spark.common.util.ThreadFinder;
+import me.lucko.spark.proto.SparkProtos;
+
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation of {@link ThreadDumper} that generates data for a regex matched set of threads.
+ */
+public final class PatternThreadDumper implements ThreadDumper {
+
+    private final ThreadFinder threadFinder = new ThreadFinder();
+    private final Set<Pattern> namePatterns;
+    private final Map<Long, Boolean> cache = new HashMap<>();
+
+    public PatternThreadDumper(Set<String> namePatterns) {
+        this.namePatterns = namePatterns.stream()
+                .map(regex -> {
+                    try {
+                        return Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+                    } catch (PatternSyntaxException e) {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public ThreadInfo[] dumpThreads(ThreadMXBean threadBean) {
+        return this.threadFinder.getThreads()
+                .filter(thread -> {
+                    Boolean result = this.cache.get(thread.getId());
+                    if (result != null) {
+                        return result;
+                    }
+
+                    for (Pattern pattern : this.namePatterns) {
+                        if (pattern.matcher(thread.getName()).matches()) {
+                            this.cache.put(thread.getId(), true);
+                            return true;
+                        }
+                    }
+                    this.cache.put(thread.getId(), false);
+                    return false;
+                })
+                .map(thread -> threadBean.getThreadInfo(thread.getId(), Integer.MAX_VALUE))
+                .filter(Objects::nonNull)
+                .toArray(ThreadInfo[]::new);
+    }
+
+    @Override
+    public SparkProtos.SamplerMetadata.ThreadDumper getMetadata() {
+        return SparkProtos.SamplerMetadata.ThreadDumper.newBuilder()
+                .setType(SparkProtos.SamplerMetadata.ThreadDumper.Type.REGEX)
+                .addAllPatterns(this.namePatterns.stream().map(Pattern::pattern).collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/dumper/SpecificThreadDumper.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/dumper/SpecificThreadDumper.java
@@ -1,0 +1,64 @@
+package me.lucko.spark.common.sampler.dumper;
+
+import me.lucko.spark.common.sampler.ThreadDumper;
+import me.lucko.spark.common.util.ThreadFinder;
+import me.lucko.spark.proto.SparkProtos;
+
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation of {@link ThreadDumper} that generates data for a specific set of threads.
+ */
+public final class SpecificThreadDumper implements ThreadDumper {
+    private final long[] ids;
+    private Set<Thread> threads;
+    private Set<String> threadNamesLowerCase;
+
+    public SpecificThreadDumper(long[] ids) {
+        this.ids = ids;
+    }
+
+    public SpecificThreadDumper(Set<String> names) {
+        this.threadNamesLowerCase = names.stream().map(String::toLowerCase).collect(Collectors.toSet());
+        this.ids = new ThreadFinder().getThreads()
+                .filter(t -> this.threadNamesLowerCase.contains(t.getName().toLowerCase()))
+                .mapToLong(Thread::getId)
+                .toArray();
+        Arrays.sort(this.ids);
+    }
+
+    public Set<Thread> getThreads() {
+        if (this.threads == null) {
+            this.threads = new ThreadFinder().getThreads()
+                    .filter(t -> Arrays.binarySearch(this.ids, t.getId()) >= 0)
+                    .collect(Collectors.toSet());
+        }
+        return this.threads;
+    }
+
+    public Set<String> getThreadNames() {
+        if (this.threadNamesLowerCase == null) {
+            this.threadNamesLowerCase = getThreads().stream()
+                    .map(t -> t.getName().toLowerCase())
+                    .collect(Collectors.toSet());
+        }
+        return this.threadNamesLowerCase;
+    }
+
+    @Override
+    public ThreadInfo[] dumpThreads(ThreadMXBean threadBean) {
+        return threadBean.getThreadInfo(this.ids, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public SparkProtos.SamplerMetadata.ThreadDumper getMetadata() {
+        return SparkProtos.SamplerMetadata.ThreadDumper.newBuilder()
+                .setType(SparkProtos.SamplerMetadata.ThreadDumper.Type.SPECIFIC)
+                .addAllIds(Arrays.stream(this.ids).boxed().collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/grouper/NameThreadGrouper.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/grouper/NameThreadGrouper.java
@@ -1,0 +1,19 @@
+package me.lucko.spark.common.sampler.grouper;
+
+import me.lucko.spark.common.sampler.ThreadGrouper;
+import me.lucko.spark.proto.SparkProtos;
+
+/**
+ * Implementation of {@link ThreadGrouper} that just groups by thread name.
+ */
+public class NameThreadGrouper implements ThreadGrouper {
+    @Override
+    public String getGroup(long threadId, String threadName) {
+        return threadName;
+    }
+
+    @Override
+    public SparkProtos.SamplerMetadata.DataAggregator.ThreadGrouper asProto() {
+        return SparkProtos.SamplerMetadata.DataAggregator.ThreadGrouper.BY_NAME;
+    }
+}

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/grouper/PoolThreadGrouper.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/grouper/PoolThreadGrouper.java
@@ -1,0 +1,44 @@
+package me.lucko.spark.common.sampler.grouper;
+
+import me.lucko.spark.common.sampler.ThreadGrouper;
+import me.lucko.spark.proto.SparkProtos;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Implementation of {@link ThreadGrouper} that attempts to group by the name of the pool
+ * the thread originated from.
+ *
+ * <p>The regex pattern used to match pools expects a digit at the end of the thread name,
+ * separated from the pool name with any of one or more of ' ', '-', or '#'.</p>
+ */
+public class PoolThreadGrouper implements ThreadGrouper {
+
+    private final Map<Long, String> cache = new ConcurrentHashMap<>();
+    private final Pattern pattern = Pattern.compile("^(.*?)[-# ]+\\d+$");
+
+    @Override
+    public String getGroup(long threadId, String threadName) {
+        String group = this.cache.get(threadId);
+        if (group != null) {
+            return group;
+        }
+
+        Matcher matcher = this.pattern.matcher(threadName);
+        if (!matcher.matches()) {
+            return threadName;
+        }
+
+        group = matcher.group(1).trim() + " (Combined)";
+        this.cache.put(threadId, group); // we don't care about race conditions here
+        return group;
+    }
+
+    @Override
+    public SparkProtos.SamplerMetadata.DataAggregator.ThreadGrouper asProto() {
+        return SparkProtos.SamplerMetadata.DataAggregator.ThreadGrouper.BY_POOL;
+    }
+}

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/grouper/SingleThreadGrouper.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/grouper/SingleThreadGrouper.java
@@ -1,0 +1,21 @@
+package me.lucko.spark.common.sampler.grouper;
+
+import me.lucko.spark.common.sampler.ThreadGrouper;
+import me.lucko.spark.proto.SparkProtos;
+
+/**
+ * Implementation of {@link ThreadGrouper} which groups all threads as one, under
+ * the name "All".
+ */
+public class SingleThreadGrouper implements ThreadGrouper {
+
+    @Override
+    public String getGroup(long threadId, String threadName) {
+        return "All";
+    }
+
+    @Override
+    public SparkProtos.SamplerMetadata.DataAggregator.ThreadGrouper asProto() {
+        return SparkProtos.SamplerMetadata.DataAggregator.ThreadGrouper.AS_ONE;
+    }
+}


### PR DESCRIPTION
Hi, @lucko 

As I wrote in #130, here is a draft PR for the Profiler API. This is just a *small* start.
This API addition will allow to programmatically start and stop the profiler.

When the profiler is stopped, a `ProfilerReport` object will be returned containing the URL to the viewer (more fields possible).

I am looking forward to hearing your thoughts about this.