### PR TITLE
Sponge8SparkPlugin: use new CommandResult.success() instead of empty()

### DIFF
--- a/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8SparkPlugin.java
+++ b/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8SparkPlugin.java
@@ -21,13 +21,16 @@
 package me.lucko.spark.sponge;
 
 import com.google.inject.Inject;
+
 import me.lucko.spark.common.SparkPlatform;
 import me.lucko.spark.common.SparkPlugin;
 import me.lucko.spark.common.command.sender.CommandSender;
 import me.lucko.spark.common.platform.PlatformInfo;
 import me.lucko.spark.common.sampler.ThreadDumper;
 import me.lucko.spark.common.tick.TickHook;
+
 import net.kyori.adventure.text.Component;
+
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.spongepowered.api.Game;
 import org.spongepowered.api.Server;
@@ -59,8 +62,9 @@ public class Sponge8SparkPlugin implements SparkPlugin {
     private final Game game;
     private final Path configDirectory;
     private final ExecutorService asyncExecutor;
-    private final ThreadDumper.GameThread threadDumper = new ThreadDumper.GameThread();
+    
     private SparkPlatform platform;
+    private final ThreadDumper.GameThread threadDumper = new ThreadDumper.GameThread();
 
     @Inject
     public Sponge8SparkPlugin(PluginContainer pluginContainer, Game game, @ConfigDir(sharedRoot = false) Path configDirectory) {

--- a/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8SparkPlugin.java
+++ b/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8SparkPlugin.java
@@ -21,16 +21,13 @@
 package me.lucko.spark.sponge;
 
 import com.google.inject.Inject;
-
 import me.lucko.spark.common.SparkPlatform;
 import me.lucko.spark.common.SparkPlugin;
 import me.lucko.spark.common.command.sender.CommandSender;
 import me.lucko.spark.common.platform.PlatformInfo;
 import me.lucko.spark.common.sampler.ThreadDumper;
 import me.lucko.spark.common.tick.TickHook;
-
 import net.kyori.adventure.text.Component;
-
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.spongepowered.api.Game;
 import org.spongepowered.api.Server;
@@ -62,9 +59,8 @@ public class Sponge8SparkPlugin implements SparkPlugin {
     private final Game game;
     private final Path configDirectory;
     private final ExecutorService asyncExecutor;
-
-    private SparkPlatform platform;
     private final ThreadDumper.GameThread threadDumper = new ThreadDumper.GameThread();
+    private SparkPlatform platform;
 
     @Inject
     public Sponge8SparkPlugin(PluginContainer pluginContainer, Game game, @ConfigDir(sharedRoot = false) Path configDirectory) {
@@ -145,7 +141,7 @@ public class Sponge8SparkPlugin implements SparkPlugin {
         public CommandResult process(CommandCause cause, ArgumentReader.Mutable arguments) {
             this.plugin.threadDumper.ensureSetup();
             this.plugin.platform.executeCommand(new Sponge8CommandSender(cause), arguments.input().split(" "));
-            return CommandResult.empty();
+            return CommandResult.success();
         }
 
         @Override

--- a/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8SparkPlugin.java
+++ b/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8SparkPlugin.java
@@ -62,7 +62,7 @@ public class Sponge8SparkPlugin implements SparkPlugin {
     private final Game game;
     private final Path configDirectory;
     private final ExecutorService asyncExecutor;
-    
+
     private SparkPlatform platform;
     private final ThreadDumper.GameThread threadDumper = new ThreadDumper.GameThread();
 


### PR DESCRIPTION
There was a breaking change in the `CommandResult` class. The `empty()` was removed in favour of a `success()` and `error(Component)` method.