### PR TITLE
Depend only on used fabric API modules

### DIFF
--- a/spark-fabric/src/main/resources/fabric.mod.json
+++ b/spark-fabric/src/main/resources/fabric.mod.json
@@ -28,6 +28,8 @@
     ],
     "depends": {
         "fabricloader": ">=0.4.0",
-        "fabric": "*"
+        "fabric-api-base": "*",
+        "fabric-command-api-v1": "*",
+        "fabric-lifecycle-events-v1" : "*"
     }
 }


### PR DESCRIPTION
Sparks fabric implementation should only depend on the fabric API modules it uses. See Luckperms [fabric module](https://github.com/lucko/LuckPerms/blob/master/fabric/src/main/resources/fabric.mod.json).