### PR TITLE
Add Forge 1.7.10 platform

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,9 @@ subprojects {
 
     tasks.withType(JavaCompile) {
         options.encoding = 'UTF-8'
-        options.release = 8
+        if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
+            options.release = 8
+        }
     }
 
     processResources {

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,6 +13,10 @@ rootProject.name = 'spark'
 include (
         'spark-api',
         'spark-common',
+        'spark-forge1122'
+)
+if (JavaVersion.current() != JavaVersion.VERSION_1_8){
+    include (
         'spark-bukkit',
         'spark-bungeecord',
         'spark-velocity',
@@ -20,9 +24,13 @@ include (
         'spark-sponge',
         'spark-sponge8',
         'spark-forge',
-        'spark-forge1122',
         'spark-fabric',
         'spark-nukkit',
         'spark-waterdog',
         'spark-universal'
-)
+    )
+} else {
+    include (
+        'spark-forge1710'
+    )
+}

--- a/spark-forge1710/build.gradle
+++ b/spark-forge1710/build.gradle
@@ -1,0 +1,86 @@
+buildscript {
+    repositories {
+        mavenCentral()
+        maven { url = "https://maven.minecraftforge.net" }
+    }
+    dependencies {
+        classpath ('com.anatawa12.forge:ForgeGradle:1.2-1.0.+') {
+            changing = true
+        }
+    }
+}
+
+plugins {
+    id 'com.github.johnrengelman.shadow' version '7.0.0'
+}
+
+apply plugin: 'forge'
+
+// These settings allow you to choose what version of Java you want to be compatible with. Forge 1.7.10 runs on Java 6 to 8.
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+minecraft {
+    version = "1.7.10-10.13.4.1614-1.7.10"
+    runDir = "run"
+    mappings = 'stable_12'
+    
+    replaceIn 'src/main/java/me/lucko/spark/forge/Forge1710SparkMod.java'
+    replace "@version@", project.pluginVersion
+}
+
+configurations {
+    shade
+    implementation.extendsFrom shade
+}
+
+// https://github.com/MinecraftForge/ForgeGradle/issues/627#issuecomment-533927535
+configurations.all {
+    resolutionStrategy {
+        force 'org.lwjgl.lwjgl:lwjgl-platform:2.9.4-nightly-20150209'
+    }
+}
+
+dependencies {
+    shade project(':spark-common')
+}
+
+processResources {
+    from(sourceSets.main.resources.srcDirs) {
+        include 'mcmod.info'
+        expand (
+                'pluginVersion': project.pluginVersion,
+                'pluginDescription': project.pluginDescription
+        )
+    }
+}
+
+shadowJar {
+    archiveName = 'spark-forge1710.jar'
+    configurations = [project.configurations.shade]
+
+    relocate 'okio', 'me.lucko.spark.lib.okio'
+    relocate 'okhttp3', 'me.lucko.spark.lib.okhttp3'
+    relocate 'net.kyori.adventure', 'me.lucko.spark.lib.adventure'
+    relocate 'net.kyori.examination', 'me.lucko.spark.lib.adventure.examination'
+    relocate 'net.bytebuddy', 'me.lucko.spark.lib.bytebuddy'
+    relocate 'org.tukaani.xz', 'me.lucko.spark.lib.xz'
+    relocate 'com.google.protobuf', 'me.lucko.spark.lib.protobuf'
+    relocate 'org.objectweb.asm', 'me.lucko.spark.lib.asm'
+    relocate 'one.profiler', 'me.lucko.spark.lib.asyncprofiler'
+
+    exclude 'module-info.class'
+    exclude 'META-INF/maven/**'
+    exclude 'META-INF/proguard/**'
+}
+
+reobf.reobf(shadowJar) { spec ->
+    spec.classpath = sourceSets.main.compileClasspath;
+}
+
+artifacts {
+    archives shadowJar
+    shadow shadowJar
+}
+
+build.dependsOn(shadowJar)

--- a/spark-forge1710/src/main/java/me/lucko/spark/forge/Forge1710CommandSender.java
+++ b/spark-forge1710/src/main/java/me/lucko/spark/forge/Forge1710CommandSender.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.forge;
+
+import me.lucko.spark.common.command.sender.AbstractCommandSender;
+import me.lucko.spark.forge.plugin.Forge1710SparkPlugin;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.network.rcon.RConConsoleSource;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.IChatComponent;
+import net.minecraftforge.common.ForgeHooks;
+
+import java.util.UUID;
+
+public class Forge1710CommandSender extends AbstractCommandSender<ICommandSender> {
+    private final Forge1710SparkPlugin plugin;
+
+    public Forge1710CommandSender(ICommandSender source, Forge1710SparkPlugin plugin) {
+        super(source);
+        this.plugin = plugin;
+    }
+
+    @Override
+    public String getName() {
+        if (super.delegate instanceof EntityPlayer) {
+            return ((EntityPlayer) super.delegate).getGameProfile().getName();
+        } else if (super.delegate instanceof MinecraftServer) {
+            return "Console";
+        } else if (super.delegate instanceof RConConsoleSource) {
+            return "RCON Console";
+        } else {
+            return "unknown:" + super.delegate.getClass().getSimpleName();
+        }
+    }
+
+    @Override
+    public UUID getUniqueId() {
+        if (super.delegate instanceof EntityPlayer) {
+            return ((EntityPlayer) super.delegate).getUniqueID();
+        }
+        return null;
+    }
+
+    @Override
+    public void sendMessage(Component message) {
+        /*
+         * Due to limitations in 1.7.10, messages with \n render incorrectly on the client.
+         * To work around this, we convert the message to a string first, split it by newline,
+         * and send each line individually.
+         * 
+         * This adds a performance penalty, but avoids any weirdness with this old client.
+         */
+        LegacyComponentSerializer serializer = LegacyComponentSerializer.builder()
+                .character(LegacyComponentSerializer.SECTION_CHAR)
+                .extractUrls()
+                .build();
+        String output = serializer.serialize(message);
+        for(String line : output.split("\n")) {
+            Component deserialized = serializer.deserialize(line);
+            IChatComponent mcComponent = IChatComponent.Serializer.jsonToComponent(GsonComponentSerializer.gson().serialize(deserialized));
+            super.delegate.addChatMessage(mcComponent);
+        }
+    }
+
+    @Override
+    public boolean hasPermission(String permission) {
+        return this.plugin.hasPermission(super.delegate, permission);
+    }
+}

--- a/spark-forge1710/src/main/java/me/lucko/spark/forge/Forge1710PlatformInfo.java
+++ b/spark-forge1710/src/main/java/me/lucko/spark/forge/Forge1710PlatformInfo.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.forge;
+
+import me.lucko.spark.common.platform.AbstractPlatformInfo;
+import net.minecraftforge.common.ForgeVersion;
+
+public class Forge1710PlatformInfo extends AbstractPlatformInfo {
+    private final Type type;
+
+    public Forge1710PlatformInfo(Type type) {
+        this.type = type;
+    }
+
+    @Override
+    public Type getType() {
+        return this.type;
+    }
+
+    @Override
+    public String getName() {
+        return "Forge";
+    }
+
+    @Override
+    public String getVersion() {
+        return ForgeVersion.getVersion();
+    }
+
+    @Override
+    public String getMinecraftVersion() {
+        return "1.7.10";
+    }
+}

--- a/spark-forge1710/src/main/java/me/lucko/spark/forge/Forge1710SparkMod.java
+++ b/spark-forge1710/src/main/java/me/lucko/spark/forge/Forge1710SparkMod.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.forge;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.Mod;
+import cpw.mods.fml.common.Mod.EventHandler;
+import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import cpw.mods.fml.common.event.FMLServerStartingEvent;
+import cpw.mods.fml.common.event.FMLServerStoppingEvent;
+import cpw.mods.fml.relauncher.Side;
+import me.lucko.spark.forge.plugin.Forge1710ClientSparkPlugin;
+import me.lucko.spark.forge.plugin.Forge1710ServerSparkPlugin;
+
+import java.nio.file.Path;
+
+@Mod(
+        modid = "spark",
+        name = "spark",
+        version = "@version@",
+        acceptableRemoteVersions = "*"
+)
+public class Forge1710SparkMod {
+
+    private Path configDirectory;
+    private Forge1710ServerSparkPlugin activeServerPlugin;
+
+    public String getVersion() {
+        return Forge1710SparkMod.class.getAnnotation(Mod.class).version();
+    }
+
+    @EventHandler
+    public void preInit(FMLPreInitializationEvent e) {
+        this.configDirectory = e.getModConfigurationDirectory().toPath();
+    }
+
+    @EventHandler
+    public void clientInit(FMLInitializationEvent e) {
+        if (FMLCommonHandler.instance().getSide() == Side.CLIENT) {
+            Forge1710ClientSparkPlugin.register(this);
+        }
+    }
+
+    @EventHandler
+    public void serverInit(FMLServerStartingEvent e) {
+        this.activeServerPlugin = Forge1710ServerSparkPlugin.register(this, e);
+    }
+
+    @EventHandler
+    public void serverStop(FMLServerStoppingEvent e) {
+        if (this.activeServerPlugin != null) {
+            this.activeServerPlugin.disable();
+            this.activeServerPlugin = null;
+        }
+    }
+
+    public Path getConfigDirectory() {
+        if (this.configDirectory == null) {
+            throw new IllegalStateException("Config directory not set");
+        }
+        return this.configDirectory;
+    }
+}

--- a/spark-forge1710/src/main/java/me/lucko/spark/forge/Forge1710TickHook.java
+++ b/spark-forge1710/src/main/java/me/lucko/spark/forge/Forge1710TickHook.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.forge;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.TickEvent;
+import me.lucko.spark.common.tick.AbstractTickHook;
+import me.lucko.spark.common.tick.TickHook;
+import net.minecraftforge.common.MinecraftForge;
+
+public class Forge1710TickHook extends AbstractTickHook implements TickHook {
+    private final TickEvent.Type type;
+
+    public Forge1710TickHook(TickEvent.Type type) {
+        this.type = type;
+    }
+
+    @SubscribeEvent
+    public void onTick(TickEvent e) {
+        if (e.phase != TickEvent.Phase.START) {
+            return;
+        }
+
+        if (e.type != this.type) {
+            return;
+        }
+
+        onTick();
+    }
+
+    @Override
+    public void start() {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @Override
+    public void close() {
+        MinecraftForge.EVENT_BUS.unregister(this);
+    }
+
+}

--- a/spark-forge1710/src/main/java/me/lucko/spark/forge/Forge1710TickReporter.java
+++ b/spark-forge1710/src/main/java/me/lucko/spark/forge/Forge1710TickReporter.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.forge;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.TickEvent;
+import me.lucko.spark.common.tick.SimpleTickReporter;
+import me.lucko.spark.common.tick.TickReporter;
+import net.minecraftforge.common.MinecraftForge;
+
+public class Forge1710TickReporter extends SimpleTickReporter implements TickReporter {
+    private final TickEvent.Type type;
+
+    public Forge1710TickReporter(TickEvent.Type type) {
+        this.type = type;
+    }
+
+    @SubscribeEvent
+    public void onTick(TickEvent e) {
+        if (e.type != this.type) {
+            return;
+        }
+
+        switch (e.phase) {
+            case START:
+                onStart();
+                break;
+            case END:
+                onEnd();
+                break;
+            default:
+                throw new AssertionError(e.phase);
+        }
+    }
+
+    @Override
+    public void start() {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @Override
+    public void close() {
+        MinecraftForge.EVENT_BUS.unregister(this);
+        super.close();
+    }
+
+}

--- a/spark-forge1710/src/main/java/me/lucko/spark/forge/plugin/Forge1710ClientSparkPlugin.java
+++ b/spark-forge1710/src/main/java/me/lucko/spark/forge/plugin/Forge1710ClientSparkPlugin.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.forge.plugin;
+
+import cpw.mods.fml.common.gameevent.TickEvent;
+import me.lucko.spark.common.platform.PlatformInfo;
+import me.lucko.spark.common.tick.TickHook;
+import me.lucko.spark.common.tick.TickReporter;
+import me.lucko.spark.forge.*;
+import net.minecraft.client.Minecraft;
+import net.minecraft.command.ICommandSender;
+import net.minecraftforge.client.ClientCommandHandler;
+import net.minecraftforge.common.MinecraftForge;
+
+import java.util.stream.Stream;
+
+public class Forge1710ClientSparkPlugin extends Forge1710SparkPlugin {
+
+    public static void register(Forge1710SparkMod mod) {
+        Forge1710ClientSparkPlugin plugin = new Forge1710ClientSparkPlugin(mod, Minecraft.getMinecraft());
+        plugin.enable();
+
+        // register listeners
+        MinecraftForge.EVENT_BUS.register(plugin);
+
+        // register commands
+        ClientCommandHandler.instance.registerCommand(plugin);
+    }
+
+    private final Minecraft minecraft;
+
+    public Forge1710ClientSparkPlugin(Forge1710SparkMod mod, Minecraft minecraft) {
+        super(mod);
+        this.minecraft = minecraft;
+    }
+
+    @Override
+    public boolean hasPermission(ICommandSender sender, String permission) {
+        return true;
+    }
+
+    @Override
+    public Stream<Forge1710CommandSender> getCommandSenders() {
+        return Stream.of(new Forge1710CommandSender(this.minecraft.thePlayer, this));
+    }
+
+    @Override
+    public TickHook createTickHook() {
+        return new Forge1710TickHook(TickEvent.Type.CLIENT);
+    }
+
+    @Override
+    public TickReporter createTickReporter() {
+        return new Forge1710TickReporter(TickEvent.Type.CLIENT);
+    }
+
+    @Override
+    public PlatformInfo getPlatformInfo() {
+        return new Forge1710PlatformInfo(PlatformInfo.Type.CLIENT);
+    }
+
+    @Override
+    public String getCommandName() {
+        return "sparkc";
+    }
+
+}

--- a/spark-forge1710/src/main/java/me/lucko/spark/forge/plugin/Forge1710ServerSparkPlugin.java
+++ b/spark-forge1710/src/main/java/me/lucko/spark/forge/plugin/Forge1710ServerSparkPlugin.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.forge.plugin;
+
+import cpw.mods.fml.common.event.FMLServerStartingEvent;
+import cpw.mods.fml.common.gameevent.TickEvent;
+import me.lucko.spark.common.platform.PlatformInfo;
+import me.lucko.spark.common.tick.TickHook;
+import me.lucko.spark.common.tick.TickReporter;
+import me.lucko.spark.forge.*;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.server.MinecraftServer;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public class Forge1710ServerSparkPlugin extends Forge1710SparkPlugin {
+
+    public static Forge1710ServerSparkPlugin register(Forge1710SparkMod mod, FMLServerStartingEvent event) {
+        Forge1710ServerSparkPlugin plugin = new Forge1710ServerSparkPlugin(mod, event.getServer());
+        plugin.enable();
+
+        // register commands & permissions
+        event.registerServerCommand(plugin);
+
+        return plugin;
+    }
+
+    private final MinecraftServer server;
+
+    public Forge1710ServerSparkPlugin(Forge1710SparkMod mod, MinecraftServer server) {
+        super(mod);
+        this.server = server;
+    }
+
+    @Override
+    public boolean hasPermission(ICommandSender sender, String permission) {
+        if (sender instanceof EntityPlayer) {
+            return isOp((EntityPlayer) sender);
+        } else {
+            return true;
+        }
+    }
+
+    @Override
+    public Stream<Forge1710CommandSender> getCommandSenders() {
+        return Stream.concat(
+                ((List<EntityPlayer>)this.server.getConfigurationManager().playerEntityList).stream(),
+            Stream.of(this.server)
+        ).map(sender -> new Forge1710CommandSender(sender, this));
+    }
+
+    @Override
+    public TickHook createTickHook() {
+        return new Forge1710TickHook(TickEvent.Type.SERVER);
+    }
+
+    @Override
+    public TickReporter createTickReporter() {
+        return new Forge1710TickReporter(TickEvent.Type.SERVER);
+    }
+
+    @Override
+    public PlatformInfo getPlatformInfo() {
+        return new Forge1710PlatformInfo(PlatformInfo.Type.SERVER);
+    }
+
+    @Override
+    public String getCommandName() {
+        return "spark";
+    }
+}

--- a/spark-forge1710/src/main/java/me/lucko/spark/forge/plugin/Forge1710SparkPlugin.java
+++ b/spark-forge1710/src/main/java/me/lucko/spark/forge/plugin/Forge1710SparkPlugin.java
@@ -1,0 +1,153 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.forge.plugin;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import me.lucko.spark.common.SparkPlatform;
+import me.lucko.spark.common.SparkPlugin;
+import me.lucko.spark.common.sampler.ThreadDumper;
+import me.lucko.spark.forge.Forge1710CommandSender;
+import me.lucko.spark.forge.Forge1710SparkMod;
+import net.minecraft.command.ICommand;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.logging.Level;
+
+public abstract class Forge1710SparkPlugin implements SparkPlugin, ICommand {
+
+    private final Forge1710SparkMod mod;
+    private final Logger logger;
+    protected final ScheduledExecutorService scheduler;
+    protected final SparkPlatform platform;
+    protected final ThreadDumper.GameThread threadDumper = new ThreadDumper.GameThread();
+
+    protected Forge1710SparkPlugin(Forge1710SparkMod mod) {
+        this.mod = mod;
+        this.logger = LogManager.getLogger("spark");
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread thread = Executors.defaultThreadFactory().newThread(r);
+            thread.setName("spark-forge-async-worker");
+            thread.setDaemon(true);
+            return thread;
+        });
+        this.platform = new SparkPlatform(this);
+    }
+
+    public void enable() {
+        this.platform.enable();
+    }
+
+    public void disable() {
+        this.platform.disable();
+        this.scheduler.shutdown();
+    }
+
+    public abstract boolean hasPermission(ICommandSender sender, String permission);
+
+    @Override
+    public String getVersion() {
+        return this.mod.getVersion();
+    }
+
+    @Override
+    public Path getPluginDirectory() {
+        return this.mod.getConfigDirectory();
+    }
+
+    @Override
+    public void executeAsync(Runnable task) {
+        this.scheduler.execute(task);
+    }
+
+    @Override
+    public void log(Level level, String msg) {
+        if (level == Level.INFO) {
+            this.logger.info(msg);
+        } else if (level == Level.WARNING) {
+            this.logger.warn(msg);
+        } else if (level == Level.SEVERE) {
+            this.logger.error(msg);
+        } else {
+            throw new IllegalArgumentException(level.getName());
+        }
+    }
+
+    @Override
+    public ThreadDumper getDefaultThreadDumper() {
+        return this.threadDumper.get();
+    }
+
+    // implement ICommand
+
+    @Override
+    public String getCommandName() {
+        return getCommandName();
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender iCommandSender) {
+        return "/" + getCommandName();
+    }
+
+    @Override
+    public List<String> getCommandAliases() {
+        return Collections.singletonList(getCommandName());
+    }
+
+    @Override
+    public void processCommand(ICommandSender sender, String[] args) {
+        this.threadDumper.ensureSetup();
+        this.platform.executeCommand(new Forge1710CommandSender(sender, this), args);
+    }
+
+    @Override
+    public List<String> addTabCompletionOptions(ICommandSender sender, String[] args) {
+        return this.platform.tabCompleteCommand(new Forge1710CommandSender(sender, this), args);
+    }
+
+    @Override
+    public boolean canCommandSenderUseCommand(ICommandSender sender) {
+        return this.platform.hasPermissionForAnyCommand(new Forge1710CommandSender(sender, this));
+    }
+
+    @Override
+    public boolean isUsernameIndex(String[] strings, int i) {
+        return false;
+    }
+
+    @Override
+    public int compareTo(Object o) {
+        return getCommandName().compareTo(((ICommand)o).getCommandName());
+    }
+    
+    protected boolean isOp(EntityPlayer player) {
+       return FMLCommonHandler.instance().getMinecraftServerInstance().getConfigurationManager().canSendCommands(player.getGameProfile());
+    }
+
+}

--- a/spark-forge1710/src/main/resources/mcmod.info
+++ b/spark-forge1710/src/main/resources/mcmod.info
@@ -1,0 +1,7 @@
+[{
+  "modid": "spark",
+  "name": "spark",
+  "description": "${pluginDescription}",
+  "version": "${pluginVersion}",
+  "authors": ["Luck"]
+}]


### PR DESCRIPTION
This PR adds support for Forge 1.7.10 to Spark.

Implementation notes:

* There is no ability to use ForgeGradle 5 with 1.7.10. Instead, ForgeGradle 1.2 has to be used, which only supports up to Java 8. At the same time, Fabric Loom insists on a newer version of Java being present or the build fails. Therefore, I had to implement logic to switch between compiling all other platforms if a version of Java other than 8 is used, and compiling the 1.7.10 version only when Java 8 is used. This will likely need some changes on the Jenkins side.
* A still-developed fork of ForgeGradle 1.2 is used so the Gradle version didn't need to be changed.
* The 1.7.10 client can't handle newlines in chat messages, so I had to manually parse, split, and send them within the platform logic. This works but there may be some small performance/memory penalty when a message is being sent. I doubt this matters.

All in all, I am quite pleased with how much code is shared between Spark platforms. Very little needed to be changed to make this work.

Build with: `./gradlew :spark-forge1710:build`