### PR TITLE
Add disableResponseBroadcast config option

### DIFF
--- a/spark-common/src/main/java/me/lucko/spark/common/SparkPlatform.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/SparkPlatform.java
@@ -206,8 +206,8 @@ public class SparkPlatform {
         return this.bytebinClient;
     }
 
-    public boolean getDisableResponseBroadcast() {
-        return this.disableResponseBroadcast;
+    public boolean shouldBroadcastResponse() {
+        return !this.disableResponseBroadcast;
     }
 
     public List<Command> getCommands() {

--- a/spark-common/src/main/java/me/lucko/spark/common/SparkPlatform.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/SparkPlatform.java
@@ -92,6 +92,7 @@ public class SparkPlatform {
     private final String viewerUrl;
     private final OkHttpClient httpClient;
     private final BytebinClient bytebinClient;
+    private final boolean disableResponseBroadcast;
     private final List<CommandModule> commandModules;
     private final List<Command> commands;
     private final ReentrantLock commandExecuteLock = new ReentrantLock(true);
@@ -114,6 +115,8 @@ public class SparkPlatform {
 
         this.httpClient = new OkHttpClient();
         this.bytebinClient = new BytebinClient(this.httpClient, bytebinUrl, "spark-plugin");
+
+        this.disableResponseBroadcast = this.configuration.getBoolean("disableResponseBroadcast", false);
 
         this.commandModules = ImmutableList.of(
                 new SamplerModule(),
@@ -201,6 +204,10 @@ public class SparkPlatform {
 
     public BytebinClient getBytebinClient() {
         return this.bytebinClient;
+    }
+
+    public boolean getDisableResponseBroadcast() {
+        return this.disableResponseBroadcast;
     }
 
     public List<Command> getCommands() {

--- a/spark-common/src/main/java/me/lucko/spark/common/command/CommandResponseHandler.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/command/CommandResponseHandler.java
@@ -88,12 +88,26 @@ public class CommandResponseHandler {
     }
 
     public void broadcast(Component message) {
-        allSenders(sender -> sender.sendMessage(message));
+        if (platform.getDisableResponseBroadcast())
+        {
+            reply(message);
+        }
+        else
+        {
+            allSenders(sender -> sender.sendMessage(message));
+        }
     }
 
     public void broadcast(Iterable<Component> message) {
-        Component joinedMsg = Component.join(JoinConfiguration.separator(Component.newline()), message);
-        allSenders(sender -> sender.sendMessage(joinedMsg));
+        if (platform.getDisableResponseBroadcast())
+        {
+            reply(message);
+        }
+        else
+        {
+            Component joinedMsg = Component.join(JoinConfiguration.separator(Component.newline()), message);
+            allSenders(sender -> sender.sendMessage(joinedMsg));
+        }
     }
 
     public void replyPrefixed(Component message) {

--- a/spark-common/src/main/java/me/lucko/spark/common/command/CommandResponseHandler.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/command/CommandResponseHandler.java
@@ -88,25 +88,19 @@ public class CommandResponseHandler {
     }
 
     public void broadcast(Component message) {
-        if (platform.getDisableResponseBroadcast())
-        {
-            reply(message);
-        }
-        else
-        {
+        if (this.platform.shouldBroadcastResponse()) {
             allSenders(sender -> sender.sendMessage(message));
+        } else {
+            reply(message);
         }
     }
 
     public void broadcast(Iterable<Component> message) {
-        if (platform.getDisableResponseBroadcast())
-        {
-            reply(message);
-        }
-        else
-        {
+        if (this.platform.shouldBroadcastResponse()) {
             Component joinedMsg = Component.join(JoinConfiguration.separator(Component.newline()), message);
             allSenders(sender -> sender.sendMessage(joinedMsg));
+        } else {
+            reply(message);
         }
     }
 


### PR DESCRIPTION
Add disableResponseBroadcast to send all command responses to the source only.

Implemented for our small SMP to enable the server tech people monitoring server performance without annoying the rest of the mod team.

Tested on fabric 1.18.1.

If you are interested in merging this, I can also open a PR to spark-docs.