### PR TITLE
Detect offline mode information

### DIFF
--- a/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitPlatformInfo.java
+++ b/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitPlatformInfo.java
@@ -82,11 +82,13 @@ public class BukkitPlatformInfo implements PlatformInfo {
         if (this.server.getOnlineMode()) {
             return OnlineMode.ONLINE;
         } else {
-            if (this.server.spigot().getPaperConfig().getBoolean("settings.velocity-support.online-mode")) {
+            if (this.server.spigot().getPaperConfig().getBoolean("settings.velocity-support.enabled")
+                    && this.server.spigot().getPaperConfig().getBoolean("settings.velocity-support.online-mode")) {
                 return OnlineMode.VELOCITY;
             }
 
-            if (this.server.spigot().getSpigotConfig().getBoolean("settings.bungeecord")) {
+            if (this.server.spigot().getSpigotConfig().getBoolean("settings.bungeecord")
+                    && this.server.spigot().getPaperConfig().getBoolean("settings.bungee-online-mode")) {
                 return OnlineMode.BUNGEE;
             }
 

--- a/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitPlatformInfo.java
+++ b/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitPlatformInfo.java
@@ -23,6 +23,7 @@ package me.lucko.spark.bukkit;
 import me.lucko.spark.common.platform.PlatformInfo;
 
 import org.bukkit.Server;
+import org.bukkit.configuration.file.YamlConfiguration;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -74,5 +75,22 @@ public class BukkitPlatformInfo implements PlatformInfo {
         }
 
         return serverClass.getPackage().getName().split("\\.")[3];
+    }
+
+    @Override
+    public OnlineMode getOnlineMode() {
+        if (this.server.getOnlineMode()) {
+            return OnlineMode.ONLINE;
+        } else {
+            if (this.server.spigot().getPaperConfig().getBoolean("settings.velocity-support.online-mode")) {
+                return OnlineMode.VELOCITY;
+            }
+
+            if (this.server.spigot().getSpigotConfig().getBoolean("settings.bungeecord")) {
+                return OnlineMode.BUNGEE;
+            }
+
+            return OnlineMode.OFFLINE;
+        }
     }
 }

--- a/spark-bungeecord/src/main/java/me/lucko/spark/bungeecord/BungeeCordPlatformInfo.java
+++ b/spark-bungeecord/src/main/java/me/lucko/spark/bungeecord/BungeeCordPlatformInfo.java
@@ -50,4 +50,13 @@ public class BungeeCordPlatformInfo implements PlatformInfo {
     public String getMinecraftVersion() {
         return null;
     }
+
+    @Override
+    public OnlineMode getOnlineMode() {
+        if (this.proxy.getConfig().isOnlineMode()) {
+            return OnlineMode.ONLINE;
+        } else {
+            return OnlineMode.OFFLINE;
+        }
+    }
 }

--- a/spark-common/src/main/java/me/lucko/spark/common/platform/PlatformInfo.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/platform/PlatformInfo.java
@@ -39,8 +39,12 @@ public interface PlatformInfo {
         return DATA_VERSION;
     }
 
+    default OnlineMode getOnlineMode() {
+        return OnlineMode.UNKNOWN;
+    }
+
     default Data toData() {
-        return new Data(getType(), getName(), getVersion(), getMinecraftVersion(), getSparkVersion());
+        return new Data(getType(), getName(), getVersion(), getMinecraftVersion(), getSparkVersion(), getOnlineMode());
     }
 
     enum Type {
@@ -59,19 +63,39 @@ public interface PlatformInfo {
         }
     }
 
+    enum OnlineMode {
+        UNKNOWN(PlatformMetadata.OnlineMode.UNKNOWN),
+        ONLINE(PlatformMetadata.OnlineMode.ONLINE),
+        OFFLINE(PlatformMetadata.OnlineMode.OFFLINE),
+        BUNGEE(PlatformMetadata.OnlineMode.BUNGEE),
+        VELOCITY(PlatformMetadata.OnlineMode.VELOCITY);
+
+        private final PlatformMetadata.OnlineMode onlineMode;
+
+        OnlineMode(PlatformMetadata.OnlineMode onlineMode) {
+            this.onlineMode = onlineMode;
+        }
+
+        public PlatformMetadata.OnlineMode toProto() {
+            return this.onlineMode;
+        }
+    }
+
     final class Data {
         private final Type type;
         private final String name;
         private final String version;
         private final String minecraftVersion;
         private final int sparkVersion;
+        private final OnlineMode onlineMode;
 
-        public Data(Type type, String name, String version, String minecraftVersion, int sparkVersion) {
+        public Data(Type type, String name, String version, String minecraftVersion, int sparkVersion, OnlineMode onlineMode) {
             this.type = type;
             this.name = name;
             this.version = version;
             this.minecraftVersion = minecraftVersion;
             this.sparkVersion = sparkVersion;
+            this.onlineMode = onlineMode;
         }
 
         public Type getType() {
@@ -94,12 +118,17 @@ public interface PlatformInfo {
             return this.sparkVersion;
         }
 
+        public OnlineMode getOnlineMode() {
+            return this.onlineMode;
+        }
+
         public PlatformMetadata toProto() {
             PlatformMetadata.Builder proto = PlatformMetadata.newBuilder()
                     .setType(this.type.toProto())
                     .setName(this.name)
                     .setVersion(this.version)
-                    .setSparkVersion(this.sparkVersion);
+                    .setSparkVersion(this.sparkVersion)
+                    .setOnlineMode(this.onlineMode.toProto());
 
             if (this.minecraftVersion != null) {
                 proto.setMinecraftVersion(this.minecraftVersion);

--- a/spark-common/src/main/proto/spark/spark.proto
+++ b/spark-common/src/main/proto/spark/spark.proto
@@ -11,6 +11,7 @@ message PlatformMetadata {
   string version = 3;
   string minecraft_version = 4; // optional
   int32 spark_version = 7;
+  OnlineMode online_mode = 8;
 
   // replaced
   reserved 5, 6;
@@ -20,6 +21,14 @@ message PlatformMetadata {
     SERVER = 0;
     CLIENT = 1;
     PROXY = 2;
+  }
+
+  enum OnlineMode {
+    UNKNOWN = 0;
+    ONLINE = 1;
+    OFFLINE = 2;
+    BUNGEE = 3;
+    VELOCITY = 4;
   }
 }
 

--- a/spark-fabric/src/main/java/me/lucko/spark/fabric/FabricPlatformInfo.java
+++ b/spark-fabric/src/main/java/me/lucko/spark/fabric/FabricPlatformInfo.java
@@ -23,6 +23,7 @@ package me.lucko.spark.fabric;
 import me.lucko.spark.common.platform.PlatformInfo;
 
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.server.MinecraftServer;
 
 import java.util.Optional;
 
@@ -51,6 +52,19 @@ public class FabricPlatformInfo implements PlatformInfo {
     @Override
     public String getMinecraftVersion() {
         return getModVersion("minecraft").orElse(null);
+    }
+
+    @Override
+    public OnlineMode getOnlineMode() {
+        if (this.type == Type.SERVER) {
+            if (((MinecraftServer) FabricLoader.getInstance().getGameInstance()).isOnlineMode()) {
+                return OnlineMode.ONLINE;
+            } else {
+                return OnlineMode.OFFLINE;
+            }
+        }
+
+        return OnlineMode.UNKNOWN;
     }
 
     private Optional<String> getModVersion(String mod) {

--- a/spark-forge/src/main/java/me/lucko/spark/forge/ForgePlatformInfo.java
+++ b/spark-forge/src/main/java/me/lucko/spark/forge/ForgePlatformInfo.java
@@ -22,6 +22,9 @@ package me.lucko.spark.forge;
 
 import me.lucko.spark.common.platform.PlatformInfo;
 
+import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.common.util.LogicalSidedProvider;
+import net.minecraftforge.server.ServerLifecycleHooks;
 import net.minecraftforge.versions.forge.ForgeVersion;
 import net.minecraftforge.versions.mcp.MCPVersion;
 
@@ -50,5 +53,18 @@ public class ForgePlatformInfo implements PlatformInfo {
     @Override
     public String getMinecraftVersion() {
         return MCPVersion.getMCVersion();
+    }
+
+    @Override
+    public OnlineMode getOnlineMode() {
+        if (this.type == Type.SERVER) {
+            if (ServerLifecycleHooks.getCurrentServer().usesAuthentication()) {
+                return OnlineMode.ONLINE;
+            } else {
+                return OnlineMode.OFFLINE;
+            }
+        }
+
+        return OnlineMode.UNKNOWN;
     }
 }

--- a/spark-sponge7/src/main/java/me/lucko/spark/sponge/Sponge7PlatformInfo.java
+++ b/spark-sponge7/src/main/java/me/lucko/spark/sponge/Sponge7PlatformInfo.java
@@ -51,4 +51,13 @@ public class Sponge7PlatformInfo implements PlatformInfo {
     public String getMinecraftVersion() {
         return this.game.getPlatform().getMinecraftVersion().getName();
     }
+
+    @Override
+    public OnlineMode getOnlineMode() {
+        if (this.game.getServer().getOnlineMode()) {
+            return OnlineMode.ONLINE;
+        } else {
+            return OnlineMode.OFFLINE;
+        }
+    }
 }

--- a/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8PlatformInfo.java
+++ b/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8PlatformInfo.java
@@ -51,4 +51,13 @@ public class Sponge8PlatformInfo implements PlatformInfo {
     public String getMinecraftVersion() {
         return this.game.platform().minecraftVersion().name();
     }
+
+    @Override
+    public OnlineMode getOnlineMode() {
+        if (this.game.server().isOnlineModeEnabled()) {
+            return OnlineMode.ONLINE;
+        } else {
+            return OnlineMode.OFFLINE;
+        }
+    }
 }

--- a/spark-velocity/src/main/java/me/lucko/spark/velocity/VelocityPlatformInfo.java
+++ b/spark-velocity/src/main/java/me/lucko/spark/velocity/VelocityPlatformInfo.java
@@ -50,4 +50,13 @@ public class VelocityPlatformInfo implements PlatformInfo {
     public String getMinecraftVersion() {
         return null;
     }
+
+    @Override
+    public OnlineMode getOnlineMode() {
+        if (this.proxy.getConfiguration().isOnlineMode()) {
+            return OnlineMode.ONLINE;
+        } else {
+            return OnlineMode.OFFLINE;
+        }
+    }
 }

--- a/spark-velocity4/src/main/java/me/lucko/spark/velocity/Velocity4PlatformInfo.java
+++ b/spark-velocity4/src/main/java/me/lucko/spark/velocity/Velocity4PlatformInfo.java
@@ -50,4 +50,13 @@ public class Velocity4PlatformInfo implements PlatformInfo {
     public String getMinecraftVersion() {
         return null;
     }
+
+    @Override
+    public OnlineMode getOnlineMode() {
+        if (this.proxy.configuration().isOnlineMode()) {
+            return OnlineMode.ONLINE;
+        } else {
+            return OnlineMode.OFFLINE;
+        }
+    }
 }


### PR DESCRIPTION
This is the companion to lucko/spark-viewer#30

Many people or communities refuse to provide support to people who run offline mode. With spark currently, you would have to manually dig through the config looking for the values. This PR adds a much easier way to the viewer to find this information.