### PR TITLE
Fix build for spark-sponge7 so it will actually load on Sponge.

### DIFF
--- a/spark-sponge7/build.gradle
+++ b/spark-sponge7/build.gradle
@@ -35,6 +35,7 @@ shadowJar {
     exclude 'module-info.class'
     exclude 'META-INF/maven/**'
     exclude 'META-INF/proguard/**'
+	exclude 'META-INF/versions/**'
 }
 
 artifacts {

--- a/spark-sponge7/build.gradle
+++ b/spark-sponge7/build.gradle
@@ -35,7 +35,7 @@ shadowJar {
     exclude 'module-info.class'
     exclude 'META-INF/maven/**'
     exclude 'META-INF/proguard/**'
-	exclude 'META-INF/versions/**'
+    exclude 'META-INF/versions/**'
 }
 
 artifacts {


### PR DESCRIPTION
I modified the build.gradle for spark-sponge7 to exclude everything in `META-INF/versions` so to avoid any module-info.class files being shaded in to the final jar. Sponge will completely break if any exist, as they're meant for Java 9+, which Sponge 7 does *not* support. See issue #162. This PR resolves it.