### PR TITLE
Fix PlaceholderAPI integration on fabric

### DIFF
--- a/spark-fabric/build.gradle
+++ b/spark-fabric/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
     include(modImplementation('me.lucko:fabric-permissions-api:0.1-SNAPSHOT'))
 
-    modImplementation('eu.pb4:placeholder-api:1.1.1+1.17.1')
+    modImplementation('eu.pb4:placeholder-api:2.0.0-beta.4+1.19')
 
     shade project(':spark-common')
 }

--- a/spark-fabric/src/main/java/me/lucko/spark/fabric/placeholder/SparkFabricPlaceholderApi.java
+++ b/spark-fabric/src/main/java/me/lucko/spark/fabric/placeholder/SparkFabricPlaceholderApi.java
@@ -20,8 +20,8 @@
 
 package me.lucko.spark.fabric.placeholder;
 
-import eu.pb4.placeholders.PlaceholderAPI;
-import eu.pb4.placeholders.PlaceholderResult;
+import eu.pb4.placeholders.api.Placeholders;
+import eu.pb4.placeholders.api.PlaceholderResult;
 
 import me.lucko.spark.common.SparkPlatform;
 import me.lucko.spark.common.monitor.cpu.CpuMonitor;
@@ -40,16 +40,16 @@ public class SparkFabricPlaceholderApi {
     public SparkFabricPlaceholderApi(SparkPlatform platform) {
         this.platform = platform;
 
-        PlaceholderAPI.register(
+        Placeholders.register(
                 new Identifier("spark", "tps"),
-                context -> {
+                (context, arg) -> {
                     TickStatistics tickStatistics = platform.getTickStatistics();
                     if (tickStatistics == null) {
                         return PlaceholderResult.invalid();
                     }
 
-                    if (context.hasArgument()) {
-                        Double tps = switch (context.getArgument()) {
+                    if (arg != null) {
+                        Double tps = switch (arg) {
                             case "5s":
                                 yield tickStatistics.tps5Sec();
                             case "10s":
@@ -83,16 +83,16 @@ public class SparkFabricPlaceholderApi {
                 }
         );
 
-        PlaceholderAPI.register(
+        Placeholders.register(
                 new Identifier("spark", "tickduration"),
-                context -> {
+                (context, arg) -> {
                     TickStatistics tickStatistics = platform.getTickStatistics();
                     if (tickStatistics == null || !tickStatistics.isDurationSupported()) {
                         return PlaceholderResult.invalid();
                     }
 
-                    if (context.hasArgument()) {
-                        RollingAverage duration = switch (context.getArgument()) {
+                    if (arg != null) {
+                        RollingAverage duration = switch (arg) {
                             case "10s":
                                 yield tickStatistics.duration10Sec();
                             case "1m":
@@ -117,11 +117,11 @@ public class SparkFabricPlaceholderApi {
                 }
         );
 
-        PlaceholderAPI.register(
+        Placeholders.register(
                 new Identifier("spark", "cpu_system"),
-                context -> {
-                    if (context.hasArgument()) {
-                        Double usage = switch (context.getArgument()) {
+                (context, arg) -> {
+                    if (arg != null) {
+                        Double usage = switch (arg) {
                             case "10s":
                                 yield CpuMonitor.systemLoad10SecAvg();
                             case "1m":
@@ -149,11 +149,11 @@ public class SparkFabricPlaceholderApi {
                 }
         );
 
-        PlaceholderAPI.register(
+        Placeholders.register(
                 new Identifier("spark", "cpu_process"),
-                context -> {
-                    if (context.hasArgument()) {
-                        Double usage = switch (context.getArgument()) {
+                (context, arg) -> {
+                    if (arg != null) {
+                        Double usage = switch (arg) {
                             case "10s":
                                 yield CpuMonitor.processLoad10SecAvg();
                             case "1m":

--- a/spark-fabric/src/main/java/me/lucko/spark/fabric/plugin/FabricServerSparkPlugin.java
+++ b/spark-fabric/src/main/java/me/lucko/spark/fabric/plugin/FabricServerSparkPlugin.java
@@ -42,11 +42,15 @@ import me.lucko.spark.fabric.FabricTickReporter;
 import me.lucko.spark.fabric.placeholder.SparkFabricPlaceholderApi;
 
 import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.Version;
+import net.fabricmc.loader.api.VersionParsingException;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.command.CommandOutput;
 import net.minecraft.server.command.ServerCommandSource;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
@@ -73,8 +77,17 @@ public class FabricServerSparkPlugin extends FabricSparkPlugin implements Comman
         registerCommands(this.server.getCommandManager().getDispatcher());
 
         // placeholders
-        if (FabricLoader.getInstance().isModLoaded("placeholder-api")) {
-            new SparkFabricPlaceholderApi(this.platform);
+        Optional<ModContainer> placeholderApi = FabricLoader.getInstance().getModContainer("placeholder-api");
+        if (placeholderApi.isPresent()) {
+            try {
+                Version version = placeholderApi.get().getMetadata().getVersion();
+                if (version.compareTo(Version.parse("2.0.0-beta.1+1.19")) >= 0
+                        && version.compareTo(Version.parse("3.0.0")) < 0) {
+                    new SparkFabricPlaceholderApi(this.platform);
+                }
+            } catch (VersionParsingException ex) {
+                ex.printStackTrace();
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #212 

### Notes for review
I'm not 100% sure that `FabricLoader.getInstance().getModContainer("placeholder-api").isPresent()` functions 100% exactly the same as `FabricLoader.getInstance().isPresent("placeholder-api");` though I would be very surprised if it didn't.

I also added some version checking for breaking changes since you're not jar-in-jar-ing this and expecting it to be present in other mods, to try and prevent this sort of thing from happening in the future.

Tested with StyledChat 1.3.1 on 1.19.