### PR TITLE
Better handling of papers split config system

### DIFF
--- a/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitServerConfigProvider.java
+++ b/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitServerConfigProvider.java
@@ -89,7 +89,7 @@ public class BukkitServerConfigProvider extends AbstractServerConfigProvider {
             configs.put("global.yml", parse(Files.newBufferedReader(configDir.resolve(group + "-global.yml"))));
             configs.put("world-defaults.yml", parse(Files.newBufferedReader(configDir.resolve(group + "-world-defaults.yml"))));
             for (World world : Bukkit.getWorlds()) {
-                configs.put("world-" + world.getName() + ".yml", parse(Files.newBufferedReader(world.getWorldFolder().toPath().resolve(group + "-world.yml"))));
+                configs.put(world.getName() + ".yml", parse(Files.newBufferedReader(world.getWorldFolder().toPath().resolve(group + "-world.yml"))));
             }
 
             return configs;

--- a/spark-common/src/main/java/me/lucko/spark/common/platform/serverconfig/AbstractServerConfigProvider.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/platform/serverconfig/AbstractServerConfigProvider.java
@@ -65,16 +65,16 @@ public abstract class AbstractServerConfigProvider implements ServerConfigProvid
     public final Map<String, JsonElement> loadServerConfigurations() {
         ImmutableMap.Builder<String, JsonElement> builder = ImmutableMap.builder();
 
-        this.files.forEach((path, reader) -> {
+        this.files.forEach((name, reader) -> {
+            name = reader.getRealName(name);
+
             try {
-                JsonElement json = load(path, reader);
+                JsonElement json = load(reader.getRealName(name), reader);
                 if (json == null) {
                     return;
                 }
 
                 delete(json, this.hiddenPaths);
-
-                String name = rewriteConfigPath(path);
                 builder.put(name, json);
             } catch (Exception e) {
                 e.printStackTrace();
@@ -85,23 +85,16 @@ public abstract class AbstractServerConfigProvider implements ServerConfigProvid
     }
 
     private JsonElement load(String path, ConfigParser parser) throws IOException {
-        Path filePath = Paths.get(path);
-        if (!Files.exists(filePath)) {
+        Map<String, Object> values = parser.parse(path);
+        if (values == null) {
             return null;
         }
 
-        try (BufferedReader reader = Files.newBufferedReader(filePath, StandardCharsets.UTF_8)) {
-            Map<String, Object> values = parser.parse(reader);
-            return this.gson.toJsonTree(values);
-        }
+        return this.gson.toJsonTree(values);
     }
 
     protected void customiseGson(GsonBuilder gson) {
 
-    }
-
-    protected String rewriteConfigPath(String path) {
-        return path;
     }
 
     /**

--- a/spark-common/src/main/java/me/lucko/spark/common/platform/serverconfig/AbstractServerConfigProvider.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/platform/serverconfig/AbstractServerConfigProvider.java
@@ -65,17 +65,15 @@ public abstract class AbstractServerConfigProvider implements ServerConfigProvid
     public final Map<String, JsonElement> loadServerConfigurations() {
         ImmutableMap.Builder<String, JsonElement> builder = ImmutableMap.builder();
 
-        this.files.forEach((name, reader) -> {
-            name = reader.getRealName(name);
-
+        this.files.forEach((path, reader) -> {
             try {
-                JsonElement json = load(reader.getRealName(name), reader);
+                JsonElement json = load(path, reader);
                 if (json == null) {
                     return;
                 }
 
                 delete(json, this.hiddenPaths);
-                builder.put(name, json);
+                builder.put(path, json);
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/spark-common/src/main/java/me/lucko/spark/common/platform/serverconfig/ConfigParser.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/platform/serverconfig/ConfigParser.java
@@ -22,10 +22,29 @@ package me.lucko.spark.common.platform.serverconfig;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 
 public interface ConfigParser {
 
-    Map<String, Object> parse(BufferedReader reader) throws IOException;
+    default String getRealName(String name) {
+        return name;
+    }
+
+    default Map<String, Object> parse(String file) throws IOException {
+        Path filePath = Paths.get(file);
+        if (!Files.exists(filePath)) {
+            return null;
+        }
+
+        try (BufferedReader reader = Files.newBufferedReader(filePath, StandardCharsets.UTF_8)) {
+            return this.parse(reader);
+        }
+    }
+
+     Map<String, Object> parse(BufferedReader reader) throws IOException;
 
 }

--- a/spark-common/src/main/java/me/lucko/spark/common/platform/serverconfig/ConfigParser.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/platform/serverconfig/ConfigParser.java
@@ -31,12 +31,15 @@ import java.util.Map;
 public interface ConfigParser {
 
     default Map<String, Object> parse(String file) throws IOException {
-        Path filePath = Paths.get(file);
-        if (!Files.exists(filePath)) {
+        return parse(Paths.get(file));
+    }
+
+    default Map<String, Object> parse(Path file) throws IOException {
+        if (!Files.exists(file)) {
             return null;
         }
 
-        try (BufferedReader reader = Files.newBufferedReader(filePath, StandardCharsets.UTF_8)) {
+        try (BufferedReader reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
             return this.parse(reader);
         }
     }

--- a/spark-common/src/main/java/me/lucko/spark/common/platform/serverconfig/ConfigParser.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/platform/serverconfig/ConfigParser.java
@@ -30,10 +30,6 @@ import java.util.Map;
 
 public interface ConfigParser {
 
-    default String getRealName(String name) {
-        return name;
-    }
-
     default Map<String, Object> parse(String file) throws IOException {
         Path filePath = Paths.get(file);
         if (!Files.exists(filePath)) {


### PR DESCRIPTION
This merges all files into the way the config looked pre-1.19. Here is an [example](https://spark.lucko.me/5H0SnMOcY1).

I'm not sure that this is the best way of doing things, we could make it look like a `paper/` folder in the editor and include files inside of it like `paper-global.yml`, `paper-world-defaults.yml`, and `paper-{world}.yml`

Let me know what you think!