### PR TITLE
Improve operating system info

### DIFF
--- a/spark-common/src/main/java/me/lucko/spark/common/monitor/os/OperatingSystemInfo.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/monitor/os/OperatingSystemInfo.java
@@ -53,7 +53,7 @@ public enum OperatingSystemInfo {
             for (final String line : LinuxProc.OSINFO.read()) {
                 if (line.startsWith("PRETTY_NAME")) {
                     try {
-                        name = line.substring(12).trim();
+                        name = line.substring(13).replace('"', ' ').trim();
                     } catch (final IndexOutOfBoundsException e) {
                         // ignore
                     }

--- a/spark-common/src/main/java/me/lucko/spark/common/monitor/os/OperatingSystemInfo.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/monitor/os/OperatingSystemInfo.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.common.monitor.os;
+
+import me.lucko.spark.common.util.LinuxProc;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public enum OperatingSystemInfo {
+    ;
+
+    private static String name = null;
+    private static String version = null;
+
+    static {
+        final String osNameJavaProp = System.getProperty("os.name");
+
+        if (osNameJavaProp.startsWith("Windows")) {
+            final String[] args = { "wmic", "os", "get", "caption,version", "/FORMAT:list" };
+            try (final BufferedReader buf = new BufferedReader(new InputStreamReader(new ProcessBuilder(args).redirectErrorStream(true).start().getInputStream()))) {
+                String line;
+                while ((line = buf.readLine()) != null) {
+                    if (line.startsWith("Caption")) {
+                        name = line.substring(18).trim();
+                    } else if (line.startsWith("Version")) {
+                        version = line.substring(8).trim();
+                    }
+                }
+            } catch (final IOException | IndexOutOfBoundsException e) {
+                // ignore
+            }
+        } else {
+            for (final String line : LinuxProc.OSINFO.read()) {
+                if (line.startsWith("PRETTY_NAME")) {
+                    try {
+                        name = line.substring(12).trim();
+                    } catch (final IndexOutOfBoundsException e) {
+                        // ignore
+                    }
+                }
+            }
+        }
+
+        if (name == null)
+            name = osNameJavaProp;
+
+        if (version == null)
+            version = System.getProperty("os.version");
+    }
+
+    public static String getName() {
+        return name;
+    }
+
+    public static String getVersion() {
+        return version;
+    }
+}

--- a/spark-common/src/main/java/me/lucko/spark/common/platform/PlatformStatisticsProvider.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/platform/PlatformStatisticsProvider.java
@@ -28,6 +28,7 @@ import me.lucko.spark.common.monitor.memory.GarbageCollectorStatistics;
 import me.lucko.spark.common.monitor.memory.MemoryInfo;
 import me.lucko.spark.common.monitor.net.NetworkInterfaceAverages;
 import me.lucko.spark.common.monitor.net.NetworkMonitor;
+import me.lucko.spark.common.monitor.os.OperatingSystemInfo;
 import me.lucko.spark.common.monitor.ping.PingStatistics;
 import me.lucko.spark.common.monitor.tick.TickStatistics;
 import me.lucko.spark.common.platform.world.WorldInfoProvider;
@@ -87,8 +88,8 @@ public class PlatformStatisticsProvider {
                 )
                 .setOs(SystemStatistics.Os.newBuilder()
                         .setArch(System.getProperty("os.arch"))
-                        .setName(System.getProperty("os.name"))
-                        .setVersion(System.getProperty("os.version"))
+                        .setName(OperatingSystemInfo.getName())
+                        .setVersion(OperatingSystemInfo.getVersion())
                         .build()
                 )
                 .setJava(SystemStatistics.Java.newBuilder()

--- a/spark-common/src/main/java/me/lucko/spark/common/util/LinuxProc.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/util/LinuxProc.java
@@ -49,7 +49,12 @@ public enum LinuxProc {
     /**
      * Information about the system network usage.
      */
-    NET_DEV("/proc/net/dev");
+    NET_DEV("/proc/net/dev"),
+
+    /**
+     * Information about the operating system distro.
+     */
+    OSINFO("/etc/os-release");
 
     private final Path path;
 


### PR DESCRIPTION
This PR improves the quality of the OS info in Spark reports.

Before:
"The system is running Windows 10 (amd64) version "10.0" and has 24 CPU threads available."

After:
"The system is running Windows 11 Pro Insider Preview (amd64) version "10.0.25163" and has 24 CPU threads available."

On Windows it uses the OS caption and version fields from `wmic`, similar to #237. On Linux, it uses the pretty_name in `/etc/os-release`. A fallback to the os.name and os.version Java system properties has also been implemented and will produce the same results as before this PR when used.