### PR TITLE
Properly display mod information for mixin injected methods

### DIFF
--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/AbstractSampler.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/AbstractSampler.java
@@ -164,12 +164,16 @@ public abstract class AbstractSampler implements Sampler {
             classSourceVisitor.visit(entry);
         }
 
-        if (classSourceVisitor.hasMappings()) {
-            proto.putAllClassSources(classSourceVisitor.getMapping());
+        if (classSourceVisitor.hasClassSourceMappings()) {
+            proto.putAllClassSources(classSourceVisitor.getClassSourceMapping());
         }
 
         if (classSourceVisitor.hasMethodSourceMappings()) {
             proto.putAllMethodSources(classSourceVisitor.getMethodSourceMapping());
+        }
+
+        if (classSourceVisitor.hasLineSourceMappings()) {
+            proto.putAllLineSources(classSourceVisitor.getLineSourceMapping());
         }
     }
 }

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/AbstractSampler.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/AbstractSampler.java
@@ -167,5 +167,9 @@ public abstract class AbstractSampler implements Sampler {
         if (classSourceVisitor.hasMappings()) {
             proto.putAllClassSources(classSourceVisitor.getMapping());
         }
+
+        if (classSourceVisitor.hasMethodSourceMappings()) {
+            proto.putAllMethodSources(classSourceVisitor.getMethodSourceMapping());
+        }
     }
 }

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/async/AsyncDataAggregator.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/async/AsyncDataAggregator.java
@@ -34,6 +34,7 @@ public class AsyncDataAggregator extends AbstractDataAggregator {
     /** A describer for async-profiler stack trace elements. */
     private static final StackTraceNode.Describer<AsyncStackTraceElement> STACK_TRACE_DESCRIBER = (element, parent) ->
             new StackTraceNode.Description(element.getClassName(), element.getMethodName(), element.getMethodDescription());
+
     protected AsyncDataAggregator(ThreadGrouper threadGrouper) {
         super(threadGrouper);
     }

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/async/AsyncDataAggregator.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/async/AsyncDataAggregator.java
@@ -34,7 +34,6 @@ public class AsyncDataAggregator extends AbstractDataAggregator {
     /** A describer for async-profiler stack trace elements. */
     private static final StackTraceNode.Describer<AsyncStackTraceElement> STACK_TRACE_DESCRIBER = (element, parent) ->
             new StackTraceNode.Description(element.getClassName(), element.getMethodName(), element.getMethodDescription());
-
     protected AsyncDataAggregator(ThreadGrouper threadGrouper) {
         super(threadGrouper);
     }

--- a/spark-common/src/main/proto/spark/spark_sampler.proto
+++ b/spark-common/src/main/proto/spark/spark_sampler.proto
@@ -11,6 +11,7 @@ message SamplerData {
   SamplerMetadata metadata = 1;
   repeated ThreadNode threads = 2;
   map<string, string> class_sources = 3; // optional
+  map<string, string> method_sources = 4; // optional
 }
 
 message SamplerMetadata {

--- a/spark-common/src/main/proto/spark/spark_sampler.proto
+++ b/spark-common/src/main/proto/spark/spark_sampler.proto
@@ -12,6 +12,7 @@ message SamplerData {
   repeated ThreadNode threads = 2;
   map<string, string> class_sources = 3; // optional
   map<string, string> method_sources = 4; // optional
+  map<string, string> line_sources = 5; // optional
 }
 
 message SamplerMetadata {

--- a/spark-fabric/build.gradle
+++ b/spark-fabric/build.gradle
@@ -66,6 +66,10 @@ processResources {
     }
 }
 
+license {
+    exclude '**/smap/SMAPSourceDebugExtension.java'
+}
+
 shadowJar {
     archiveFileName = "spark-fabric-${project.pluginVersion}-dev.jar"
     configurations = [project.configurations.shade]
@@ -74,12 +78,16 @@ shadowJar {
     relocate 'net.kyori.examination', 'me.lucko.spark.lib.adventure.examination'
     relocate 'net.bytebuddy', 'me.lucko.spark.lib.bytebuddy'
     relocate 'com.google.protobuf', 'me.lucko.spark.lib.protobuf'
-    relocate 'org.objectweb.asm', 'me.lucko.spark.lib.asm'
+//    relocate 'org.objectweb.asm', 'me.lucko.spark.lib.asm'
     relocate 'one.profiler', 'me.lucko.spark.lib.asyncprofiler'
 
     exclude 'module-info.class'
     exclude 'META-INF/maven/**'
     exclude 'META-INF/proguard/**'
+
+    dependencies {
+        exclude(dependency('org.ow2.asm::'))
+    }
 }
 
 task remappedShadowJar(type: RemapJarTask) {

--- a/spark-fabric/src/main/java/me/lucko/spark/fabric/FabricClassSourceLookup.java
+++ b/spark-fabric/src/main/java/me/lucko/spark/fabric/FabricClassSourceLookup.java
@@ -22,16 +22,30 @@ package me.lucko.spark.fabric;
 
 import com.google.common.collect.ImmutableMap;
 
+import me.lucko.spark.common.util.ClassFinder;
 import me.lucko.spark.common.util.ClassSourceLookup;
 
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.objectweb.asm.Type;
+import org.spongepowered.asm.mixin.FabricUtil;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+import org.spongepowered.asm.mixin.transformer.ClassInfo;
+import org.spongepowered.asm.mixin.transformer.meta.MixinMerged;
 
+import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 
 public class FabricClassSourceLookup extends ClassSourceLookup.ByCodeSource {
+
+    private final ClassFinder classFinder = new ClassFinder();
+
     private final Path modsDirectory;
     private final Map<Path, String> pathToModMap;
 
@@ -55,11 +69,84 @@ public class FabricClassSourceLookup extends ClassSourceLookup.ByCodeSource {
         return super.identifyFileName(this.modsDirectory.relativize(path).toString());
     }
 
+    @Override
+    public @Nullable String identify(String className, String methodName, String desc, int lineNumber) throws Exception {
+        if (methodName.equals("<init>") || methodName.equals("<clinit>")) return null;
+        Method reflectMethod = null;
+        if (desc != null) {
+            Class<?> clazz = this.classFinder.findClass(className);
+            if (clazz == null) return null;
+            final Type methodType = Type.getMethodType(desc);
+            Class<?>[] params = new Class[methodType.getArgumentTypes().length];
+            Type[] argumentTypes = methodType.getArgumentTypes();
+            for (int i = 0, argumentTypesLength = argumentTypes.length; i < argumentTypesLength; i++) {
+                Type argumentType = argumentTypes[i];
+                params[i] = getClassFromType(argumentType);
+            }
+            reflectMethod = clazz.getDeclaredMethod(methodName, params);
+        }
+        if (reflectMethod == null) return null;
+
+        final MixinMerged annotation = reflectMethod.getDeclaredAnnotation(MixinMerged.class);
+        if (annotation == null) return null;
+//        System.out.println("Found annotation " + annotation);
+
+        final ClassInfo classInfo = ClassInfo.forName(className);
+//        final ClassInfo.Method method = classInfo.findMethod(methodName, desc, ClassInfo.INCLUDE_ALL);
+
+        Set<IMixinInfo> mixinInfoSet;
+
+        try {
+            Method getMixins = ClassInfo.class.getDeclaredMethod("getMixins");
+            getMixins.setAccessible(true);
+            mixinInfoSet = (Set<IMixinInfo>) getMixins.invoke(classInfo);
+        } catch (Exception e) {
+            // Fabric loader >=0.12.0 proguards out this method; use the field instead
+            var mixinsField = ClassInfo.class.getDeclaredField("mixins");
+            mixinsField.setAccessible(true);
+            mixinInfoSet = (Set<IMixinInfo>) mixinsField.get(classInfo);
+        }
+
+        if (mixinInfoSet == null) return null;
+
+        for (IMixinInfo mixin : mixinInfoSet) {
+            if (mixin.getClassName().equals(annotation.mixin())) {
+                final String modId = mixin.getConfig().getDecoration(FabricUtil.KEY_MOD_ID);
+                if (modId != null) {
+                    return modId;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private Class<?> getClassFromType(Type type) {
+        return switch (type.getSort()) {
+            case Type.VOID -> void.class;
+            case Type.BOOLEAN -> boolean.class;
+            case Type.CHAR -> char.class;
+            case Type.BYTE -> byte.class;
+            case Type.SHORT -> short.class;
+            case Type.INT -> int.class;
+            case Type.FLOAT -> float.class;
+            case Type.LONG -> long.class;
+            case Type.DOUBLE -> double.class;
+            case Type.ARRAY -> {
+                final Class<?> classFromType = getClassFromType(type.getElementType());
+                yield classFromType != null ? classFromType.arrayType() : null;
+            }
+            case Type.OBJECT -> this.classFinder.findClass(type.getClassName());
+            default -> null;
+        };
+    }
+
     private static Map<Path, String> constructPathToModIdMap(Collection<ModContainer> mods) {
         ImmutableMap.Builder<Path, String> builder = ImmutableMap.builder();
         for (ModContainer mod : mods) {
-            Path path = mod.getRootPath().toAbsolutePath().normalize();
-            builder.put(path, mod.getMetadata().getId());
+            for (Path path : mod.getRootPaths()) {
+                builder.put(path.toAbsolutePath().normalize(), mod.getMetadata().getId());
+            }
         }
         return builder.build();
     }

--- a/spark-fabric/src/main/java/me/lucko/spark/fabric/plugin/FabricSparkMixinPlugin.java
+++ b/spark-fabric/src/main/java/me/lucko/spark/fabric/plugin/FabricSparkMixinPlugin.java
@@ -1,0 +1,105 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.fabric.plugin;
+
+import org.objectweb.asm.tree.AnnotationNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.spongepowered.asm.mixin.MixinEnvironment;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+import org.spongepowered.asm.mixin.transformer.IMixinTransformer;
+import org.spongepowered.asm.mixin.transformer.ext.Extensions;
+import org.spongepowered.asm.mixin.transformer.ext.IExtension;
+import org.spongepowered.asm.mixin.transformer.ext.IExtensionRegistry;
+import org.spongepowered.asm.mixin.transformer.ext.ITargetClassContext;
+
+import java.util.List;
+import java.util.Set;
+
+public class FabricSparkMixinPlugin implements IMixinConfigPlugin, IExtension {
+    @Override
+    public void onLoad(String mixinPackage) {
+        Object transformer = MixinEnvironment.getCurrentEnvironment().getActiveTransformer();
+        if (!(transformer instanceof IMixinTransformer)) throw new IllegalStateException("Running with an odd transformer: " + transformer);
+
+        IExtensionRegistry extensions = ((IMixinTransformer) transformer).getExtensions();
+        if (!(extensions instanceof Extensions)) throw new IllegalStateException("Running with odd extensions: " + extensions);
+
+        ((Extensions) extensions).add(this);
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+
+    @Override
+    public boolean checkActive(MixinEnvironment environment) {
+        return true;
+    }
+
+    @Override
+    public void preApply(ITargetClassContext context) {
+
+    }
+
+    @Override
+    public void postApply(ITargetClassContext context) {
+
+    }
+
+    @Override
+    public void export(MixinEnvironment env, String name, boolean force, ClassNode classNode) {
+        for (MethodNode method : classNode.methods) {
+            for (AnnotationNode annotationNode : method.visibleAnnotations) {
+
+            }
+
+        }
+
+    }
+}

--- a/spark-fabric/src/main/java/me/lucko/spark/fabric/smap/SMAPPool.java
+++ b/spark-fabric/src/main/java/me/lucko/spark/fabric/smap/SMAPPool.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.fabric.smap;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public class SMAPPool {
+
+    private static final ConcurrentHashMap<String, String> SOURCE_DEBUG_POOL = new ConcurrentHashMap<>();
+
+    public static void add(String className, String sourceDebug) {
+        if (className == null || sourceDebug == null) return;
+        SOURCE_DEBUG_POOL.put(className, sourceDebug);
+    }
+
+    public static String getPooled(String className) {
+        return SOURCE_DEBUG_POOL.get(className);
+    }
+
+    private SMAPPool() {
+    }
+
+}

--- a/spark-fabric/src/main/java/me/lucko/spark/fabric/smap/SMAPSourceDebugExtension.java
+++ b/spark-fabric/src/main/java/me/lucko/spark/fabric/smap/SMAPSourceDebugExtension.java
@@ -1,0 +1,232 @@
+/*
+ * SMAPSourceDebugExtension.java - Parse source debug extensions and
+ * enhance stack traces.
+ *
+ * Copyright (c) 2012 Michael Schierl
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * - Neither name of the copyright holders nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND THE CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR THE CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package me.lucko.spark.fabric.smap;
+
+import org.jetbrains.annotations.Nullable;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+import org.spongepowered.asm.mixin.transformer.ClassInfo;
+import org.spongepowered.asm.service.MixinService;
+
+import java.util.*;
+import java.util.regex.*;
+
+/**
+ * Utility class to parse Source Debug Extensions and enhance stack traces.
+ *
+ * Note that only the first stratum is parsed and used.
+ *
+ * @author Michael Schierl
+ */
+public class SMAPSourceDebugExtension {
+
+    /**
+     * Enhance a stack trace with information from source debug extensions.
+     *
+     * @param t
+     *            Throwable whose stack trace should be enhanced
+     * @param keepOriginalFrames
+     *            Whether to keep the original frames referring to Java source
+     *            or drop them
+     * @param packageNames
+     *            Names of packages that should be scanned for source debug
+     *            extensions, or empty to scan all packages
+     */
+    public static void enhanceStackTrace(Throwable t, boolean keepOriginalFrames, String... packageNames) {
+        enhanceStackTrace(t, new HashMap<>(), keepOriginalFrames);
+    }
+
+    /**
+     * Enhance a stack trace with information from source debug extensions.
+     * Provide a custom cache of already resolved and parsed source debug
+     * extensions, to avoid parsing them for every new exception.
+     *
+     * @param t                  Throwable whose stack trace should be enhanced
+     * @param cache              Cache to be used and filled
+     * @param keepOriginalFrames Whether to keep the original frames referring to Java source
+     *                           or drop them
+     */
+    public static void enhanceStackTrace(Throwable t, Map<String, SMAPSourceDebugExtension> cache, boolean keepOriginalFrames) {
+        StackTraceElement[] elements = t.getStackTrace();
+        List<StackTraceElement> newElements = null;
+        for (int i = 0; i < elements.length; i++) {
+            String className = elements[i].getClassName();
+            SMAPSourceDebugExtension smap = getSMAPSourceDebugExtension(className, cache);
+            StackTraceElement newFrame = null;
+            if (smap != null) {
+                int[] inputLineInfo = smap.reverseLineMapping.get(elements[i].getLineNumber());
+                if (inputLineInfo != null && elements[i].getFileName().equals(smap.generatedFileName)) {
+                    FileInfo inputFileInfo = smap.fileinfo.get(inputLineInfo[0]);
+                    if (inputFileInfo != null) {
+                        final IMixinInfo mixin = findMixin(inputFileInfo.path);
+                        newFrame = new StackTraceElement(elements[i].getClassName(), elements[i].getMethodName(),
+                                findBestName(inputFileInfo.name, inputFileInfo.path, "Unspecified") + (mixin != null ? " [%s]".formatted(mixin.getConfig().getName()) : ""), inputLineInfo[1]);
+                    }
+                }
+            }
+            if (newFrame != null) {
+                if (newElements == null) {
+                    newElements = new ArrayList<>(Arrays.asList(elements).subList(0, i));
+                }
+                if (keepOriginalFrames)
+                    newElements.add(elements[i]);
+                newElements.add(newFrame);
+            } else if (newElements != null) {
+                newElements.add(elements[i]);
+            }
+        }
+        if (newElements != null) {
+            t.setStackTrace(newElements.toArray(StackTraceElement[]::new));
+        }
+        if (t.getCause() != null)
+            enhanceStackTrace(t.getCause(), cache, keepOriginalFrames);
+    }
+
+    @Nullable
+    public static SMAPSourceDebugExtension getSMAPSourceDebugExtension(String className, Map<String, SMAPSourceDebugExtension> cache) {
+        SMAPSourceDebugExtension smap = cache.get(className);
+        if (smap == null) {
+            String value = SMAPPool.getPooled(className);
+            if (value == null) {
+                try {
+                    final ClassNode classNode = MixinService.getService().getBytecodeProvider().getClassNode(className.replace('.', '/'));
+                    if (classNode != null) {
+                        value = classNode.sourceDebug;
+                    }
+                } catch (Exception ignored) {
+                }
+            }
+            if (value != null) {
+                value = value.replaceAll("\r\n?", "\n");
+                if (value.startsWith("SMAP\n")) {
+                    smap = new SMAPSourceDebugExtension(value);
+                    cache.put(className, smap);
+                }
+            }
+        }
+        return smap;
+    }
+
+    public static IMixinInfo getMixinConfigFor(String className, int lineNumber, Map<String, SMAPSourceDebugExtension> cache) {
+        final SMAPSourceDebugExtension smap = getSMAPSourceDebugExtension(className, cache);
+        if (smap != null) {
+            int[] inputLineInfo = smap.reverseLineMapping.get(lineNumber);
+            if (inputLineInfo != null) {
+                FileInfo inputFileInfo = smap.fileinfo.get(inputLineInfo[0]);
+                if (inputFileInfo != null) {
+                    return findMixin(inputFileInfo.path);
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String findBestName(String name, String path, String fallback) {
+        if (path != null) return path;
+        if (name != null && !name.equals("null")) return name;
+        return fallback;
+    }
+
+    private static IMixinInfo findMixin(String path) {
+        if (path != null && path.endsWith(".java")) {
+            ClassInfo info = ClassInfo.fromCache(path.substring(0, path.length() - 5));
+
+            if (info != null && info.isMixin()) {
+                final Iterator<IMixinInfo> iterator = info.getAppliedMixins().iterator();
+                if (iterator.hasNext()) return iterator.next();
+            }
+        }
+        return null;
+    }
+
+    private final String generatedFileName, firstStratum;
+    private final Map<Integer, FileInfo> fileinfo = new HashMap<Integer, FileInfo>();
+    private final Map<Integer, int[]> reverseLineMapping = new HashMap<Integer, int[]>();
+
+    private static final Pattern LINE_INFO_PATTERN = Pattern.compile("([0-9]+)(?:#([0-9]+))?(?:,([0-9]+))?:([0-9]+)(?:,([0-9]+))?");
+
+    private SMAPSourceDebugExtension(String value) {
+        String[] lines = value.split("\n");
+        if (!lines[0].equals("SMAP") || !lines[3].startsWith("*S ") || !lines[4].equals("*F"))
+            throw new IllegalArgumentException(value);
+        generatedFileName = lines[1];
+        firstStratum = lines[3].substring(3);
+        int idx = 5;
+        while (!lines[idx].startsWith("*")) {
+            String infoline = lines[idx++], path = null;
+            if (infoline.startsWith("+ ")) {
+                path = lines[idx++];
+                infoline = infoline.substring(2);
+            }
+            int pos = infoline.indexOf(" ");
+            int filenum = Integer.parseInt(infoline.substring(0, pos));
+            String name = infoline.substring(pos + 1);
+            fileinfo.put(filenum, new FileInfo(name, path == null ? name : path));
+        }
+        if (lines[idx].equals("*L")) {
+            idx++;
+            int lastLFI = 0;
+            while (!lines[idx].startsWith("*")) {
+                Matcher m = LINE_INFO_PATTERN.matcher(lines[idx++]);
+                if (!m.matches())
+                    throw new IllegalArgumentException(lines[idx - 1]);
+                int inputStartLine = Integer.parseInt(m.group(1));
+                int lineFileID = m.group(2) == null ? lastLFI : Integer.parseInt(m.group(2));
+                int repeatCount = m.group(3) == null ? 1 : Integer.parseInt(m.group(3));
+                int outputStartLine = Integer.parseInt(m.group(4));
+                int outputLineIncrement = m.group(5) == null ? 1 : Integer.parseInt(m.group(5));
+                for (int i = 0; i < repeatCount; i++) {
+                    int[] inputMapping = new int[] { lineFileID, inputStartLine + i };
+                    int baseOL = outputStartLine + i * outputLineIncrement;
+                    for (int ol = baseOL; ol < baseOL + outputLineIncrement; ol++) {
+                        if (!reverseLineMapping.containsKey(ol))
+                            reverseLineMapping.put(ol, inputMapping);
+                    }
+                }
+                lastLFI = lineFileID;
+            }
+        }
+    }
+
+    private static class FileInfo {
+        public final String name, path;
+
+        public FileInfo(String name, String path) {
+            this.name = name;
+            this.path = path;
+        }
+    }
+}

--- a/spark-fabric/src/main/resources/spark.mixins.json
+++ b/spark-fabric/src/main/resources/spark.mixins.json
@@ -11,5 +11,6 @@
   "server": [
     "ServerEntityManagerAccessor",
     "ServerWorldAccessor"
-  ]
+  ],
+  "plugin": "me.lucko.spark.fabric.plugin.FabricSparkMixinPlugin"
 }


### PR DESCRIPTION
This PR adds the ability to display mod information for mixin injected methods on fabric platform. 

This PR requires lucko/spark-viewer#49 . 
