### PR TITLE
Background/continuous profiling

### DIFF
--- a/spark-common/src/main/java/me/lucko/spark/common/SparkPlatform.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/SparkPlatform.java
@@ -45,6 +45,7 @@ import me.lucko.spark.common.monitor.ping.PingStatistics;
 import me.lucko.spark.common.monitor.ping.PlayerPingProvider;
 import me.lucko.spark.common.monitor.tick.TickStatistics;
 import me.lucko.spark.common.platform.PlatformStatisticsProvider;
+import me.lucko.spark.common.sampler.SamplerContainer;
 import me.lucko.spark.common.sampler.source.ClassSourceLookup;
 import me.lucko.spark.common.tick.TickHook;
 import me.lucko.spark.common.tick.TickReporter;
@@ -98,6 +99,7 @@ public class SparkPlatform {
     private final List<Command> commands;
     private final ReentrantLock commandExecuteLock = new ReentrantLock(true);
     private final ActivityLog activityLog;
+    private final SamplerContainer samplerContainer;
     private final TickHook tickHook;
     private final TickReporter tickReporter;
     private final TickStatistics tickStatistics;
@@ -136,6 +138,8 @@ public class SparkPlatform {
 
         this.activityLog = new ActivityLog(plugin.getPluginDirectory().resolve("activity.json"));
         this.activityLog.load();
+
+        this.samplerContainer = new SamplerContainer();
 
         this.tickHook = plugin.createTickHook();
         this.tickReporter = plugin.createTickReporter();
@@ -227,6 +231,10 @@ public class SparkPlatform {
 
     public ActivityLog getActivityLog() {
         return this.activityLog;
+    }
+
+    public SamplerContainer getSamplerContainer() {
+        return this.samplerContainer;
     }
 
     public TickHook getTickHook() {

--- a/spark-common/src/main/java/me/lucko/spark/common/command/Arguments.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/command/Arguments.java
@@ -38,8 +38,9 @@ public class Arguments {
 
     private final List<String> rawArgs;
     private final SetMultimap<String, String> parsedArgs;
+    private String parsedSubCommand = null;
 
-    public Arguments(List<String> rawArgs) {
+    public Arguments(List<String> rawArgs, boolean allowSubCommand) {
         this.rawArgs = rawArgs;
         this.parsedArgs = HashMultimap.create();
 
@@ -52,7 +53,9 @@ public class Arguments {
             Matcher matcher = FLAG_REGEX.matcher(arg);
             boolean matches = matcher.matches();
 
-            if (flag == null || matches) {
+            if (i == 0 && allowSubCommand && !matches) {
+                this.parsedSubCommand = arg;
+            } else if (flag == null || matches) {
                 if (!matches) {
                     throw new ParseException("Expected flag at position " + i + " but got '" + arg + "' instead!");
                 }
@@ -78,6 +81,10 @@ public class Arguments {
 
     public List<String> raw() {
         return this.rawArgs;
+    }
+
+    public String subCommand() {
+        return this.parsedSubCommand;
     }
 
     public int intFlag(String key) {

--- a/spark-common/src/main/java/me/lucko/spark/common/command/modules/GcMonitoringModule.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/command/modules/GcMonitoringModule.java
@@ -123,7 +123,7 @@ public class GcMonitoringModule implements CommandModule {
                         );
                         report.add(text()
                                 .content("      ")
-                                .append(text(formatTime((long) averageFrequency), WHITE))
+                                .append(text(FormatUtil.formatSeconds((long) averageFrequency / 1000), WHITE))
                                 .append(text(" avg frequency", GRAY))
                                 .build()
                         );
@@ -151,26 +151,6 @@ public class GcMonitoringModule implements CommandModule {
                 })
                 .build()
         );
-    }
-
-    private static String formatTime(long millis) {
-        if (millis <= 0) {
-            return "0s";
-        }
-
-        long second = millis / 1000;
-        long minute = second / 60;
-        second = second % 60;
-
-        StringBuilder sb = new StringBuilder();
-        if (minute != 0) {
-            sb.append(minute).append("m ");
-        }
-        if (second != 0) {
-            sb.append(second).append("s ");
-        }
-
-        return sb.toString().trim();
     }
 
     private static class ReportingGcMonitor extends GarbageCollectionMonitor implements GarbageCollectionMonitor.Listener {

--- a/spark-common/src/main/java/me/lucko/spark/common/command/modules/SamplerModule.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/command/modules/SamplerModule.java
@@ -39,6 +39,7 @@ import me.lucko.spark.common.sampler.async.AsyncSampler;
 import me.lucko.spark.common.sampler.node.MergeMode;
 import me.lucko.spark.common.sampler.source.ClassSourceLookup;
 import me.lucko.spark.common.tick.TickHook;
+import me.lucko.spark.common.util.FormatUtil;
 import me.lucko.spark.common.util.MethodDisambiguator;
 import me.lucko.spark.proto.SparkSamplerProtos;
 
@@ -72,31 +73,36 @@ public class SamplerModule implements CommandModule {
     public void registerCommands(Consumer<Command> consumer) {
         consumer.accept(Command.builder()
                 .aliases("profiler", "sampler")
-                .argumentUsage("info", null)
-                .argumentUsage("stop", null)
-                .argumentUsage("timeout", "timeout seconds")
-                .argumentUsage("thread *", null)
-                .argumentUsage("thread", "thread name")
-                .argumentUsage("only-ticks-over", "tick length millis")
-                .argumentUsage("interval", "interval millis")
+                .allowSubCommand(true)
+                .argumentUsage("info", "", null)
+                .argumentUsage("start", "timeout", "timeout seconds")
+                .argumentUsage("start", "thread *", null)
+                .argumentUsage("start", "thread", "thread name")
+                .argumentUsage("start", "only-ticks-over", "tick length millis")
+                .argumentUsage("start", "interval", "interval millis")
+                .argumentUsage("stop", "", null)
+                .argumentUsage("cancel", "", null)
                 .executor(this::profiler)
                 .tabCompleter((platform, sender, arguments) -> {
-                    if (arguments.contains("--info") || arguments.contains("--cancel")) {
-                        return Collections.emptyList();
-                    }
+                    List<String> opts = Collections.emptyList();
 
-                    if (arguments.contains("--stop") || arguments.contains("--upload")) {
-                        return TabCompleter.completeForOpts(arguments, "--comment", "--save-to-file");
+                    if (arguments.size() > 0) {
+                        String subCommand = arguments.get(0);
+                        if (subCommand.equals("stop") || subCommand.equals("upload")) {
+                            opts = new ArrayList<>(Arrays.asList("--comment", "--save-to-file"));
+                            opts.removeAll(arguments);
+                        }
+                        if (subCommand.equals("start")) {
+                            opts = new ArrayList<>(Arrays.asList("--timeout", "--regex", "--combine-all",
+                                    "--not-combined", "--interval", "--only-ticks-over", "--force-java-sampler"));
+                            opts.removeAll(arguments);
+                            opts.add("--thread"); // allowed multiple times
+                        }
                     }
-
-                    List<String> opts = new ArrayList<>(Arrays.asList("--info", "--stop", "--cancel",
-                            "--timeout", "--regex", "--combine-all", "--not-combined", "--interval",
-                            "--only-ticks-over", "--force-java-sampler"));
-                    opts.removeAll(arguments);
-                    opts.add("--thread"); // allowed multiple times
 
                     return TabCompleter.create()
-                            .from(0, CompletionSupplier.startsWith(opts))
+                            .at(0, CompletionSupplier.startsWith(Arrays.asList("info", "start", "stop", "cancel")))
+                            .from(1, CompletionSupplier.startsWith(opts))
                             .complete(arguments);
                 })
                 .build()
@@ -104,28 +110,48 @@ public class SamplerModule implements CommandModule {
     }
 
     private void profiler(SparkPlatform platform, CommandSender sender, CommandResponseHandler resp, Arguments arguments) {
-        if (arguments.boolFlag("info")) {
+        String subCommand = arguments.subCommand() == null ? "" : arguments.subCommand();
+
+        if (subCommand.equals("info") || arguments.boolFlag("info")) {
             profilerInfo(platform, resp);
             return;
         }
 
-        if (arguments.boolFlag("cancel")) {
+        if (subCommand.equals("cancel") || arguments.boolFlag("cancel")) {
             profilerCancel(platform, resp);
             return;
         }
 
-        if (arguments.boolFlag("stop") || arguments.boolFlag("upload")) {
+        if (subCommand.equals("stop") || arguments.boolFlag("stop") || arguments.boolFlag("upload")) {
             profilerStop(platform, sender, resp, arguments);
             return;
         }
 
-        profilerStart(platform, sender, resp, arguments);
+        if (subCommand.equals("start") || arguments.boolFlag("start")) {
+            profilerStart(platform, sender, resp, arguments);
+            return;
+        }
+
+        if (arguments.raw().isEmpty()) {
+            profilerInfo(platform, resp);
+        } else {
+            profilerStart(platform, sender, resp, arguments);
+        }
     }
 
     private void profilerStart(SparkPlatform platform, CommandSender sender, CommandResponseHandler resp, Arguments arguments) {
-        if (platform.getSamplerContainer().getActiveSampler() != null) {
-            profilerInfo(platform, resp);
-            return;
+        Sampler previousSampler = platform.getSamplerContainer().getActiveSampler();
+        if (previousSampler != null) {
+            if (previousSampler.isRunningInBackground()) {
+                // there is a background profiler running - stop that first
+                resp.replyPrefixed(text("Stopping the background profiler before starting... please wait"));
+                previousSampler.stop();
+                platform.getSamplerContainer().unsetActiveSampler(previousSampler);
+            } else {
+                // there is a non-background profiler running - tell the user
+                profilerInfo(platform, resp);
+                return;
+            }
         }
 
         int timeoutSeconds = arguments.intFlag("timeout");
@@ -212,9 +238,9 @@ public class SamplerModule implements CommandModule {
         if (timeoutSeconds == -1) {
             resp.broadcastPrefixed(text("It will run in the background until it is stopped by an admin."));
             resp.broadcastPrefixed(text("To stop the profiler and upload the results, run:"));
-            resp.broadcastPrefixed(cmdPrompt("/" + platform.getPlugin().getCommandName() + " profiler --stop"));
+            resp.broadcastPrefixed(cmdPrompt("/" + platform.getPlugin().getCommandName() + " profiler stop"));
         } else {
-            resp.broadcastPrefixed(text("The results will be automatically returned after the profiler has been running for " + timeoutSeconds + " seconds."));
+            resp.broadcastPrefixed(text("The results will be automatically returned after the profiler has been running for " + FormatUtil.formatSeconds(timeoutSeconds) + "."));
         }
 
         CompletableFuture<Sampler> future = sampler.getFuture();
@@ -248,24 +274,34 @@ public class SamplerModule implements CommandModule {
         if (sampler == null) {
             resp.replyPrefixed(text("The profiler isn't running!"));
             resp.replyPrefixed(text("To start a new one, run:"));
-            resp.replyPrefixed(cmdPrompt("/" + platform.getPlugin().getCommandName() + " profiler"));
+            resp.replyPrefixed(cmdPrompt("/" + platform.getPlugin().getCommandName() + " profiler start"));
         } else {
             resp.replyPrefixed(text("Profiler is already running!", GOLD));
 
             long runningTime = (System.currentTimeMillis() - sampler.getStartTime()) / 1000L;
-            resp.replyPrefixed(text("So far, it has profiled for " + runningTime + " seconds."));
+
+            if (sampler.isRunningInBackground()) {
+                resp.replyPrefixed(text()
+                        .append(text("It was started "))
+                        .append(text("automatically", WHITE))
+                        .append(text(" when spark enabled and has been running in the background for " + FormatUtil.formatSeconds(runningTime) + "."))
+                        .build()
+                );
+            } else {
+                resp.replyPrefixed(text("So far, it has profiled for " + FormatUtil.formatSeconds(runningTime) + "."));
+            }
 
             long timeout = sampler.getAutoEndTime();
             if (timeout == -1) {
                 resp.replyPrefixed(text("To stop the profiler and upload the results, run:"));
-                resp.replyPrefixed(cmdPrompt("/" + platform.getPlugin().getCommandName() + " profiler --stop"));
+                resp.replyPrefixed(cmdPrompt("/" + platform.getPlugin().getCommandName() + " profiler stop"));
             } else {
                 long timeoutDiff = (timeout - System.currentTimeMillis()) / 1000L;
-                resp.replyPrefixed(text("It is due to complete automatically and upload results in " + timeoutDiff + " seconds."));
+                resp.replyPrefixed(text("It is due to complete automatically and upload results in " + FormatUtil.formatSeconds(timeoutDiff) + "."));
             }
 
             resp.replyPrefixed(text("To cancel the profiler without uploading the results, run:"));
-            resp.replyPrefixed(cmdPrompt("/" + platform.getPlugin().getCommandName() + " profiler --cancel"));
+            resp.replyPrefixed(cmdPrompt("/" + platform.getPlugin().getCommandName() + " profiler cancel"));
         }
     }
 
@@ -299,6 +335,17 @@ public class SamplerModule implements CommandModule {
             MethodDisambiguator methodDisambiguator = new MethodDisambiguator();
             MergeMode mergeMode = arguments.boolFlag("separate-parent-calls") ? MergeMode.separateParentCalls(methodDisambiguator) : MergeMode.sameMethod(methodDisambiguator);
             handleUpload(platform, resp, sampler, comment, mergeMode, saveToFile);
+
+            // if the previous sampler was running in the background, create a new one
+            if (platform.getSamplerContainer().isBackgroundProfilerEnabled()) {
+                platform.startBackgroundProfiler();
+
+                resp.broadcastPrefixed(text()
+                        .append(text("Restarted the background profiler. "))
+                        .append(text("(If you don't want this to happen, run: /" + platform.getPlugin().getCommandName() + " profiler cancel)", DARK_GRAY))
+                        .build()
+                );
+            }
         }
     }
 

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/AbstractSampler.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/AbstractSampler.java
@@ -32,8 +32,6 @@ import me.lucko.spark.common.sampler.source.ClassSourceLookup;
 import me.lucko.spark.common.sampler.source.SourceMetadata;
 import me.lucko.spark.common.sampler.window.ProtoTimeEncoder;
 import me.lucko.spark.common.sampler.window.WindowStatisticsCollector;
-import me.lucko.spark.common.tick.TickHook;
-import me.lucko.spark.proto.SparkProtos;
 import me.lucko.spark.proto.SparkSamplerProtos.SamplerData;
 import me.lucko.spark.proto.SparkSamplerProtos.SamplerMetadata;
 
@@ -64,6 +62,9 @@ public abstract class AbstractSampler implements Sampler {
     /** The unix timestamp (in millis) when this sampler should automatically complete. */
     protected final long autoEndTime; // -1 for nothing
 
+    /** If the sampler is running in the background */
+    protected boolean background;
+
     /** Collects statistics for each window in the sample */
     protected final WindowStatisticsCollector windowStatisticsCollector;
 
@@ -73,11 +74,12 @@ public abstract class AbstractSampler implements Sampler {
     /** The garbage collector statistics when profiling started */
     protected Map<String, GarbageCollectorStatistics> initialGcStats;
 
-    protected AbstractSampler(SparkPlatform platform, int interval, ThreadDumper threadDumper, long autoEndTime) {
+    protected AbstractSampler(SparkPlatform platform, SamplerSettings settings) {
         this.platform = platform;
-        this.interval = interval;
-        this.threadDumper = threadDumper;
-        this.autoEndTime = autoEndTime;
+        this.interval = settings.interval();
+        this.threadDumper = settings.threadDumper();
+        this.autoEndTime = settings.autoEndTime();
+        this.background = settings.runningInBackground();
         this.windowStatisticsCollector = new WindowStatisticsCollector(platform);
     }
 
@@ -92,6 +94,11 @@ public abstract class AbstractSampler implements Sampler {
     @Override
     public long getAutoEndTime() {
         return this.autoEndTime;
+    }
+
+    @Override
+    public boolean isRunningInBackground() {
+        return this.background;
     }
 
     @Override

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/Sampler.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/Sampler.java
@@ -58,6 +58,13 @@ public interface Sampler {
     long getAutoEndTime();
 
     /**
+     * If this sampler is running in the background. (wasn't started by a specific user)
+     *
+     * @return true if the sampler is running in the background
+     */
+    boolean isRunningInBackground();
+
+    /**
      * Gets a future to encapsulate the completion of the sampler
      *
      * @return a future

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/SamplerBuilder.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/SamplerBuilder.java
@@ -38,7 +38,8 @@ public class SamplerBuilder {
     private boolean ignoreSleeping = false;
     private boolean ignoreNative = false;
     private boolean useAsyncProfiler = true;
-    private long timeout = -1;
+    private long autoEndTime = -1;
+    private boolean background = false;
     private ThreadDumper threadDumper = ThreadDumper.ALL;
     private ThreadGrouper threadGrouper = ThreadGrouper.BY_NAME;
 
@@ -57,7 +58,12 @@ public class SamplerBuilder {
         if (timeout <= 0) {
             throw new IllegalArgumentException("timeout > 0");
         }
-        this.timeout = System.currentTimeMillis() + unit.toMillis(timeout);
+        this.autoEndTime = System.currentTimeMillis() + unit.toMillis(timeout);
+        return this;
+    }
+
+    public SamplerBuilder background(boolean background) {
+        this.background = background;
         return this;
     }
 
@@ -95,26 +101,22 @@ public class SamplerBuilder {
     public Sampler start(SparkPlatform platform) {
         boolean onlyTicksOverMode = this.ticksOver != -1 && this.tickHook != null;
         boolean canUseAsyncProfiler = this.useAsyncProfiler &&
+                !onlyTicksOverMode &&
                 !(this.ignoreSleeping || this.ignoreNative) &&
                 !(this.threadDumper instanceof ThreadDumper.Regex) &&
                 AsyncProfilerAccess.getInstance(platform).checkSupported(platform);
 
 
         int intervalMicros = (int) (this.samplingInterval * 1000d);
+        SamplerSettings settings = new SamplerSettings(intervalMicros, this.threadDumper, this.threadGrouper, this.autoEndTime, this.background);
 
         Sampler sampler;
-        if (onlyTicksOverMode) {
-            sampler = new JavaSampler(platform, intervalMicros, this.threadDumper,
-                    this.threadGrouper, this.timeout, this.ignoreSleeping, this.ignoreNative,
-                    this.tickHook, this.ticksOver);
-
-        } else if (canUseAsyncProfiler) {
-            sampler = new AsyncSampler(platform, intervalMicros, this.threadDumper,
-                    this.threadGrouper, this.timeout);
-
+        if (canUseAsyncProfiler) {
+            sampler = new AsyncSampler(platform, settings);
+        } else if (onlyTicksOverMode) {
+            sampler = new JavaSampler(platform, settings, this.ignoreSleeping, this.ignoreNative, this.tickHook, this.ticksOver);
         } else {
-            sampler = new JavaSampler(platform, intervalMicros, this.threadDumper,
-                    this.threadGrouper, this.timeout, this.ignoreSleeping, this.ignoreNative);
+            sampler = new JavaSampler(platform, settings, this.ignoreSleeping, this.ignoreNative);
         }
 
         sampler.start();

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/SamplerContainer.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/SamplerContainer.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.common.sampler;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Container for the active sampler.
+ */
+public class SamplerContainer implements AutoCloseable {
+
+    private final AtomicReference<Sampler> activeSampler = new AtomicReference<>();
+
+    /**
+     * Gets the active sampler, or null if a sampler is not active.
+     *
+     * @return the active sampler
+     */
+    public Sampler getActiveSampler() {
+        return this.activeSampler.get();
+    }
+
+    /**
+     * Sets the active sampler, throwing an exception if another sampler is already active.
+     *
+     * @param sampler the sampler
+     */
+    public void setActiveSampler(Sampler sampler) {
+        if (!this.activeSampler.compareAndSet(null, sampler)) {
+            throw new IllegalStateException("Attempted to set active sampler when another was already active!");
+        }
+    }
+
+    /**
+     * Unsets the active sampler, if the provided sampler is active.
+     *
+     * @param sampler the sampler
+     */
+    public void unsetActiveSampler(Sampler sampler) {
+        this.activeSampler.compareAndSet(sampler, null);
+    }
+
+    /**
+     * Stops the active sampler, if there is one.
+     */
+    public void stopActiveSampler() {
+        Sampler sampler = this.activeSampler.getAndSet(null);
+        if (sampler != null) {
+            sampler.stop();
+        }
+    }
+
+    @Override
+    public void close() {
+        stopActiveSampler();
+    }
+
+}

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/SamplerContainer.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/SamplerContainer.java
@@ -28,6 +28,11 @@ import java.util.concurrent.atomic.AtomicReference;
 public class SamplerContainer implements AutoCloseable {
 
     private final AtomicReference<Sampler> activeSampler = new AtomicReference<>();
+    private final boolean backgroundProfilerEnabled;
+
+    public SamplerContainer(boolean backgroundProfilerEnabled) {
+        this.backgroundProfilerEnabled = backgroundProfilerEnabled;
+    }
 
     /**
      * Gets the active sampler, or null if a sampler is not active.
@@ -66,6 +71,10 @@ public class SamplerContainer implements AutoCloseable {
         if (sampler != null) {
             sampler.stop();
         }
+    }
+
+    public boolean isBackgroundProfilerEnabled() {
+        return this.backgroundProfilerEnabled;
     }
 
     @Override

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/SamplerSettings.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/SamplerSettings.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.common.sampler;
+
+/**
+ * Base settings for all samplers
+ */
+public class SamplerSettings {
+
+    private final int interval;
+    private final ThreadDumper threadDumper;
+    private final ThreadGrouper threadGrouper;
+    private final long autoEndTime;
+    private final boolean runningInBackground;
+
+    public SamplerSettings(int interval, ThreadDumper threadDumper, ThreadGrouper threadGrouper, long autoEndTime, boolean runningInBackground) {
+        this.interval = interval;
+        this.threadDumper = threadDumper;
+        this.threadGrouper = threadGrouper;
+        this.autoEndTime = autoEndTime;
+        this.runningInBackground = runningInBackground;
+    }
+
+    public int interval() {
+        return this.interval;
+    }
+
+    public ThreadDumper threadDumper() {
+        return this.threadDumper;
+    }
+
+    public ThreadGrouper threadGrouper() {
+        return this.threadGrouper;
+    }
+
+    public long autoEndTime() {
+        return this.autoEndTime;
+    }
+
+    public boolean runningInBackground() {
+        return this.runningInBackground;
+    }
+}

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/aggregator/AbstractDataAggregator.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/aggregator/AbstractDataAggregator.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.IntPredicate;
 
 /**
  * Abstract implementation of {@link DataAggregator}.
@@ -49,6 +50,11 @@ public abstract class AbstractDataAggregator implements DataAggregator {
             return node;
         }
         return this.threadData.computeIfAbsent(group, ThreadNode::new);
+    }
+
+    @Override
+    public void pruneData(IntPredicate timeWindowPredicate) {
+        this.threadData.values().removeIf(node -> node.removeTimeWindowsRecursively(timeWindowPredicate));
     }
 
     @Override

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/aggregator/DataAggregator.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/aggregator/DataAggregator.java
@@ -24,6 +24,7 @@ import me.lucko.spark.common.sampler.node.ThreadNode;
 import me.lucko.spark.proto.SparkSamplerProtos.SamplerMetadata;
 
 import java.util.List;
+import java.util.function.IntPredicate;
 
 /**
  * Aggregates sampling data.
@@ -36,6 +37,13 @@ public interface DataAggregator {
      * @return the output data
      */
     List<ThreadNode> exportData();
+
+    /**
+     * Prunes windows of data from this aggregator if the given {@code timeWindowPredicate} returns true.
+     *
+     * @param timeWindowPredicate the predicate
+     */
+    void pruneData(IntPredicate timeWindowPredicate);
 
     /**
      * Gets metadata about the data aggregator instance.

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/java/JavaSampler.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/java/JavaSampler.java
@@ -34,8 +34,6 @@ import me.lucko.spark.common.sampler.window.WindowStatisticsCollector;
 import me.lucko.spark.common.tick.TickHook;
 import me.lucko.spark.proto.SparkSamplerProtos.SamplerData;
 
-import org.checkerframework.checker.units.qual.A;
-
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
@@ -145,10 +143,15 @@ public class JavaSampler extends AbstractSampler implements Runnable {
                 JavaSampler.this.dataAggregator.insertData(threadInfo, this.window);
             }
 
-            // if we have just stepped over into a new window, collect statistics for the previous window
+            // if we have just stepped over into a new window...
             int previousWindow = JavaSampler.this.lastWindow.getAndSet(this.window);
             if (previousWindow != 0 && previousWindow != this.window) {
+
+                // collect statistics for the previous window
                 JavaSampler.this.windowStatisticsCollector.measureNow(previousWindow);
+
+                // prune data older than the history size
+                JavaSampler.this.dataAggregator.pruneData(ProfilingWindowUtils.keepHistoryBefore(this.window));
             }
         }
     }

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/node/ThreadNode.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/node/ThreadNode.java
@@ -130,6 +130,7 @@ public final class ThreadNode extends AbstractNode {
             }
         }
 
+        removeTimeWindows(predicate);
         return getTimeWindows().isEmpty();
     }
 

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/window/ProfilingWindowUtils.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/window/ProfilingWindowUtils.java
@@ -20,8 +20,24 @@
 
 package me.lucko.spark.common.sampler.window;
 
+import me.lucko.spark.common.sampler.aggregator.DataAggregator;
+
+import java.util.function.IntPredicate;
+
 public enum ProfilingWindowUtils {
     ;
+
+    /**
+     * The size/duration of a profiling window in seconds.
+     * (1 window = 1 minute)
+     */
+    public static final int WINDOW_SIZE_SECONDS = 60;
+
+    /**
+     * The number of windows to record in continuous profiling before data is dropped.
+     * (60 windows * 1 minute = 1 hour of profiling data)
+     */
+    public static final int HISTORY_SIZE = Integer.getInteger("spark.continuousProfilingHistorySize", 60);
 
     /**
      * Gets the profiling window for the given time in unix-millis.
@@ -30,7 +46,25 @@ public enum ProfilingWindowUtils {
      * @return the window
      */
     public static int unixMillisToWindow(long time) {
-        // one window per minute
-        return (int) (time / 60_000);
+        return (int) (time / (WINDOW_SIZE_SECONDS * 1000L));
+    }
+
+    /**
+     * Gets the window at the current time.
+     *
+     * @return the window
+     */
+    public static int windowNow() {
+        return unixMillisToWindow(System.currentTimeMillis());
+    }
+
+    /**
+     * Gets a prune predicate that can be passed to {@link DataAggregator#pruneData(IntPredicate)}.
+     *
+     * @return the prune predicate
+     */
+    public static IntPredicate keepHistoryBefore(int currentWindow) {
+        // windows that were earlier than (currentWindow minus history size) should be pruned
+        return window -> window < (currentWindow - HISTORY_SIZE);
     }
 }

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/window/ProtoTimeEncoder.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/window/ProtoTimeEncoder.java
@@ -21,7 +21,6 @@
 package me.lucko.spark.common.sampler.window;
 
 import me.lucko.spark.common.sampler.async.jfr.Dictionary;
-import me.lucko.spark.common.sampler.node.AbstractNode;
 import me.lucko.spark.common.sampler.node.ThreadNode;
 
 import java.util.HashMap;
@@ -42,7 +41,7 @@ public class ProtoTimeEncoder {
     public ProtoTimeEncoder(List<ThreadNode> sourceData) {
         // get an array of all keys that show up in the source data
         this.keys = sourceData.stream()
-                .map(AbstractNode::getTimeWindows)
+                .map(n -> n.getTimeWindows().stream().mapToInt(i -> i))
                 .reduce(IntStream.empty(), IntStream::concat)
                 .distinct()
                 .sorted()
@@ -70,14 +69,14 @@ public class ProtoTimeEncoder {
      * @param times a dictionary of times (unix-time millis -> duration in microseconds)
      * @return the times encoded as a double array
      */
-    public double[] encode(Dictionary<LongAdder> times) {
+    public double[] encode(Map<Integer, LongAdder> times) {
         // construct an array of values - length needs to exactly match the
         // number of keys, even if some values are zero.
         double[] array = new double[this.keys.length];
 
         times.forEach((key, value) -> {
             // get the index for the given key
-            Integer idx = this.keysToIndex.get((int) key);
+            Integer idx = this.keysToIndex.get(key);
             if (idx == null) {
                 throw new RuntimeException("No index for key " + key + " in " + this.keysToIndex.keySet());
             }

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/window/WindowStatisticsCollector.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/window/WindowStatisticsCollector.java
@@ -30,6 +30,7 @@ import me.lucko.spark.proto.SparkProtos;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntPredicate;
 
 /**
  * Collects statistics for each profiling window.
@@ -114,6 +115,10 @@ public class WindowStatisticsCollector {
         for (int window : windows) {
             this.stats.computeIfAbsent(window, w -> ZERO);
         }
+    }
+
+    public void pruneStatistics(IntPredicate predicate) {
+        this.stats.keySet().removeIf(predicate::test);
     }
 
     public Map<Integer, SparkProtos.WindowStatistics> export() {

--- a/spark-common/src/main/java/me/lucko/spark/common/util/Configuration.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/util/Configuration.java
@@ -67,4 +67,14 @@ public final class Configuration {
         return val.isBoolean() ? val.getAsBoolean() : def;
     }
 
+    public int getInteger(String path, int def) {
+        JsonElement el = this.root.get(path);
+        if (el == null || !el.isJsonPrimitive()) {
+            return def;
+        }
+
+        JsonPrimitive val = el.getAsJsonPrimitive();
+        return val.isBoolean() ? val.getAsInt() : def;
+    }
+
 }

--- a/spark-common/src/main/java/me/lucko/spark/common/util/FormatUtil.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/util/FormatUtil.java
@@ -62,4 +62,24 @@ public enum FormatUtil {
                 .append(Component.text(unit))
                 .build();
     }
+
+    public static String formatSeconds(long seconds) {
+        if (seconds <= 0) {
+            return "0s";
+        }
+
+        long second = seconds;
+        long minute = second / 60;
+        second = second % 60;
+
+        StringBuilder sb = new StringBuilder();
+        if (minute != 0) {
+            sb.append(minute).append("m ");
+        }
+        if (second != 0) {
+            sb.append(second).append("s ");
+        }
+
+        return sb.toString().trim();
+    }
 }


### PR DESCRIPTION
This pull request implements background profiling in spark.

<img width="991" alt="Screenshot 2022-11-13 at 21 28 51" src="https://user-images.githubusercontent.com/8352868/201545536-6aafbbdc-da18-4a3c-8f12-0783c11225c8.png">

Previously, the profiler had to be manually started by an administrator, then (manually or automatically) stopped a few minutes later. If the profiler was left running for too long, a) the viewer would most likely not be able to handle the data and b) the profiler engine would eventually run out of memory.

However, after this change, these two issues are no longer a problem.

The highlights are:

* spark starts a "background" profiler when it enables, using a lower-than-normal interval of `10ms` (we can experiment to find the best default value for this)
* All profiles are now capped to 1 hour. This was made possible in part by the changes introduced in #253. We can now easily expire/delete data older than a certain time to free up memory, and can filter the 1 hour profile in the viewer with 1 minute precision.
* Users can just run `/spark profiler upload` to view the last 60 minutes worth of data.

Some other notes:

* You can still start new profilers (and specify the settings you want, such as interval/threads/etc). spark will cancel the active background profiler, then start your new one. Once you're finished, the background profiler will resume.
* The background process is configurable. It can be disabled in spark's config file, you can change the interval too.

As per https://spark.lucko.me/docs/Configuration

### plugins/spark/config.json
Create the file if it doesn't exist.
```json
{
  "backgroundProfiler": true,
  "backgroundProfilerInterval": 10
}
```



