### PR TITLE
Update minestom dependency to fix errors on boot

### DIFF
--- a/spark-minestom/build.gradle
+++ b/spark-minestom/build.gradle
@@ -9,7 +9,7 @@ tasks.withType(JavaCompile) {
 
 dependencies {
     implementation project(':spark-common')
-    compileOnly 'com.github.Minestom:Minestom:367c389bc6'
+    compileOnly 'com.github.Minestom:Minestom:1a013728fd'
     implementation 'com.google.guava:guava:19.0'
 }
 


### PR DESCRIPTION
Since https://github.com/Minestom/Minestom/commit/d7e958fa07820882150567416f76b759a1dace6d, The getLogger() function on Minestom now returns ComponentLogger instead of org.slf4j.Logger, making the extension unbootable.

This commit addresses the issue by just updating the minestom dependency