### PR TITLE
Update minestom

### DIFF
--- a/spark-minestom/build.gradle
+++ b/spark-minestom/build.gradle
@@ -9,7 +9,7 @@ tasks.withType(JavaCompile) {
 
 dependencies {
     implementation project(':spark-common')
-    compileOnly 'com.github.Minestom:Minestom:1a013728fd'
+    compileOnly 'com.github.Minestom:Minestom:eb06ba8'
     implementation 'com.google.guava:guava:19.0'
 }
 

--- a/spark-minestom/build.gradle
+++ b/spark-minestom/build.gradle
@@ -9,7 +9,7 @@ tasks.withType(JavaCompile) {
 
 dependencies {
     implementation project(':spark-common')
-    compileOnly 'com.github.Minestom:Minestom:eb06ba8'
+    compileOnly 'com.github.Minestom.Minestom:Minestom:master-SNAPSHOT'
     implementation 'com.google.guava:guava:19.0'
 }
 


### PR DESCRIPTION
When downloading the spark repository (without any of the dependencies cached) and compiling it, an error occurs.

It seems like jitpack deleted the old Minestom dependency. Therefor, I updated Minestom to the newest version. 