### PR TITLE
Allocation profiler

### DIFF
--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/AbstractSampler.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/AbstractSampler.java
@@ -126,6 +126,7 @@ public abstract class AbstractSampler implements Sampler {
 
     protected void writeMetadataToProto(SamplerData.Builder proto, SparkPlatform platform, CommandSender creator, String comment, DataAggregator dataAggregator) {
         SamplerMetadata.Builder metadata = SamplerMetadata.newBuilder()
+                .setSamplerMode(getMode().asProto())
                 .setPlatformMetadata(platform.getPlugin().getPlatformInfo().toData().toProto())
                 .setCreator(creator.toData().toProto())
                 .setStartTime(this.startTime)
@@ -187,7 +188,7 @@ public abstract class AbstractSampler implements Sampler {
 
         ClassSourceLookup.Visitor classSourceVisitor = ClassSourceLookup.createVisitor(classSourceLookup);
 
-        ProtoTimeEncoder timeEncoder = new ProtoTimeEncoder(data);
+        ProtoTimeEncoder timeEncoder = new ProtoTimeEncoder(getMode().valueTransformer(), data);
         int[] timeWindows = timeEncoder.getKeys();
         for (int timeWindow : timeWindows) {
             proto.addTimeWindows(timeWindow);

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/Sampler.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/Sampler.java
@@ -65,6 +65,13 @@ public interface Sampler {
     boolean isRunningInBackground();
 
     /**
+     * Gets the sampler mode.
+     *
+     * @return the sampler mode
+     */
+    SamplerMode getMode();
+
+    /**
      * Gets a future to encapsulate the completion of the sampler
      *
      * @return a future

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/SamplerBuilder.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/SamplerBuilder.java
@@ -23,6 +23,7 @@ package me.lucko.spark.common.sampler;
 import me.lucko.spark.common.SparkPlatform;
 import me.lucko.spark.common.sampler.async.AsyncProfilerAccess;
 import me.lucko.spark.common.sampler.async.AsyncSampler;
+import me.lucko.spark.common.sampler.async.SampleCollector;
 import me.lucko.spark.common.sampler.java.JavaSampler;
 import me.lucko.spark.common.tick.TickHook;
 
@@ -34,10 +35,12 @@ import java.util.concurrent.TimeUnit;
 @SuppressWarnings("UnusedReturnValue")
 public class SamplerBuilder {
 
-    private double samplingInterval = 4; // milliseconds
+    private SamplerMode mode = SamplerMode.EXECUTION;
+    private double samplingInterval = -1;
     private boolean ignoreSleeping = false;
     private boolean ignoreNative = false;
     private boolean useAsyncProfiler = true;
+    private boolean allocLiveOnly = false;
     private long autoEndTime = -1;
     private boolean background = false;
     private ThreadDumper threadDumper = ThreadDumper.ALL;
@@ -47,6 +50,11 @@ public class SamplerBuilder {
     private TickHook tickHook = null;
 
     public SamplerBuilder() {
+    }
+
+    public SamplerBuilder mode(SamplerMode mode) {
+        this.mode = mode;
+        return this;
     }
 
     public SamplerBuilder samplingInterval(double samplingInterval) {
@@ -98,7 +106,16 @@ public class SamplerBuilder {
         return this;
     }
 
-    public Sampler start(SparkPlatform platform) {
+    public SamplerBuilder allocLiveOnly(boolean allocLiveOnly) {
+        this.allocLiveOnly = allocLiveOnly;
+        return this;
+    }
+
+    public Sampler start(SparkPlatform platform) throws UnsupportedOperationException {
+        if (this.samplingInterval <= 0) {
+            throw new IllegalArgumentException("samplingInterval = " + this.samplingInterval);
+        }
+
         boolean onlyTicksOverMode = this.ticksOver != -1 && this.tickHook != null;
         boolean canUseAsyncProfiler = this.useAsyncProfiler &&
                 !onlyTicksOverMode &&
@@ -106,13 +123,22 @@ public class SamplerBuilder {
                 !(this.threadDumper instanceof ThreadDumper.Regex) &&
                 AsyncProfilerAccess.getInstance(platform).checkSupported(platform);
 
+        if (this.mode == SamplerMode.ALLOCATION && (!canUseAsyncProfiler || !AsyncProfilerAccess.getInstance(platform).checkAllocationProfilingSupported(platform))) {
+            throw new UnsupportedOperationException("Allocation profiling is not supported on your system. Check the console for more info.");
+        }
 
-        int intervalMicros = (int) (this.samplingInterval * 1000d);
-        SamplerSettings settings = new SamplerSettings(intervalMicros, this.threadDumper, this.threadGrouper, this.autoEndTime, this.background);
+        int interval = (int) (this.mode == SamplerMode.EXECUTION ?
+                this.samplingInterval * 1000d : // convert to microseconds
+                this.samplingInterval
+        );
+
+        SamplerSettings settings = new SamplerSettings(interval, this.threadDumper, this.threadGrouper, this.autoEndTime, this.background);
 
         Sampler sampler;
-        if (canUseAsyncProfiler) {
-            sampler = new AsyncSampler(platform, settings);
+        if (this.mode == SamplerMode.ALLOCATION) {
+            sampler = new AsyncSampler(platform, settings, new SampleCollector.Allocation(interval, this.allocLiveOnly));
+        } else if (canUseAsyncProfiler) {
+            sampler = new AsyncSampler(platform, settings, new SampleCollector.Execution(interval));
         } else if (onlyTicksOverMode) {
             sampler = new JavaSampler(platform, settings, this.ignoreSleeping, this.ignoreNative, this.tickHook, this.ticksOver);
         } else {

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/SamplerMode.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/SamplerMode.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.common.sampler;
+
+import me.lucko.spark.proto.SparkSamplerProtos.SamplerMetadata;
+
+import java.util.function.LongToDoubleFunction;
+
+public enum SamplerMode {
+
+    EXECUTION(
+            value -> {
+                // convert the duration from microseconds -> milliseconds
+                return value / 1000d;
+            },
+            4, // ms
+            SamplerMetadata.SamplerMode.EXECUTION
+    ),
+
+    ALLOCATION(
+            value -> {
+                // do nothing
+                return value;
+            },
+            524287, // 512 KiB
+            SamplerMetadata.SamplerMode.ALLOCATION
+    );
+
+    private final LongToDoubleFunction valueTransformer;
+    private final int defaultInterval;
+    private final SamplerMetadata.SamplerMode proto;
+
+    SamplerMode(LongToDoubleFunction valueTransformer, int defaultInterval, SamplerMetadata.SamplerMode proto) {
+        this.valueTransformer = valueTransformer;
+        this.defaultInterval = defaultInterval;
+        this.proto = proto;
+    }
+
+    public LongToDoubleFunction valueTransformer() {
+        return this.valueTransformer;
+    }
+
+    public int defaultInterval() {
+        return this.defaultInterval;
+    }
+
+    /**
+     * Gets the metadata enum instance for this sampler mode.
+     *
+     * @return proto metadata
+     */
+    public SamplerMetadata.SamplerMode asProto() {
+        return this.proto;
+    }
+
+}

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/async/AsyncDataAggregator.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/async/AsyncDataAggregator.java
@@ -50,7 +50,7 @@ public class AsyncDataAggregator extends AbstractDataAggregator {
     public void insertData(ProfileSegment element, int window) {
         try {
             ThreadNode node = getNode(this.threadGrouper.getGroup(element.getNativeThreadId(), element.getThreadName()));
-            node.log(STACK_TRACE_DESCRIBER, element.getStackTrace(), element.getTime(), window);
+            node.log(STACK_TRACE_DESCRIBER, element.getStackTrace(), element.getValue(), window);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/async/AsyncProfilerJob.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/async/AsyncProfilerJob.java
@@ -20,6 +20,8 @@
 
 package me.lucko.spark.common.sampler.async;
 
+import com.google.common.collect.ImmutableList;
+
 import me.lucko.spark.common.SparkPlatform;
 import me.lucko.spark.common.sampler.ThreadDumper;
 import me.lucko.spark.common.sampler.async.jfr.JfrReader;
@@ -29,8 +31,8 @@ import one.profiler.AsyncProfiler;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 
@@ -77,8 +79,8 @@ public class AsyncProfilerJob {
     // Set on init
     /** The platform */
     private SparkPlatform platform;
-    /** The sampling interval in microseconds */
-    private int interval;
+    /** The sample collector */
+    private SampleCollector<?> sampleCollector;
     /** The thread dumper */
     private ThreadDumper threadDumper;
     /** The profiling window */
@@ -100,9 +102,9 @@ public class AsyncProfilerJob {
      * @param command the command
      * @return the output
      */
-    private String execute(String command) {
+    private String execute(Collection<String> command) {
         try {
-            return this.profiler.execute(command);
+            return this.profiler.execute(String.join(",", command));
         } catch (IOException e) {
             throw new RuntimeException("Exception whilst executing profiler command", e);
         }
@@ -118,9 +120,9 @@ public class AsyncProfilerJob {
     }
 
     // Initialise the job
-    public void init(SparkPlatform platform, int interval, ThreadDumper threadDumper, int window, boolean quiet) {
+    public void init(SparkPlatform platform, SampleCollector<?> collector, ThreadDumper threadDumper, int window, boolean quiet) {
         this.platform = platform;
-        this.interval = interval;
+        this.sampleCollector = collector;
         this.threadDumper = threadDumper;
         this.window = window;
         this.quiet = quiet;
@@ -141,16 +143,20 @@ public class AsyncProfilerJob {
             }
 
             // construct a command to send to async-profiler
-            String command = "start,event=" + this.access.getProfilingEvent() + ",interval=" + this.interval + "us,threads,jfr,file=" + this.outputFile.toString();
+            ImmutableList.Builder<String> command = ImmutableList.<String>builder()
+                    .add("start")
+                    .addAll(this.sampleCollector.initArguments(this.access))
+                    .add("threads").add("jfr").add("file=" + this.outputFile.toString());
+
             if (this.quiet) {
-                command += ",loglevel=NONE";
+                command.add("loglevel=NONE");
             }
             if (this.threadDumper instanceof ThreadDumper.Specific) {
-                command += ",filter";
+                command.add("filter");
             }
 
             // start the profiler
-            String resp = execute(command).trim();
+            String resp = execute(command.build()).trim();
 
             if (!resp.equalsIgnoreCase("profiling started")) {
                 throw new RuntimeException("Unexpected response: " + resp);
@@ -208,7 +214,7 @@ public class AsyncProfilerJob {
 
         // read the jfr file produced by async-profiler
         try (JfrReader reader = new JfrReader(this.outputFile)) {
-            readSegments(reader, threadFilter, dataAggregator, this.window);
+            readSegments(reader, this.sampleCollector, threadFilter, dataAggregator);
         } catch (Exception e) {
             boolean fileExists;
             try {
@@ -235,22 +241,9 @@ public class AsyncProfilerJob {
         }
     }
 
-    private void readSegments(JfrReader reader, Predicate<String> threadFilter, AsyncDataAggregator dataAggregator, int window) throws IOException {
-        List<JfrReader.ExecutionSample> samples = reader.readAllEvents(JfrReader.ExecutionSample.class);
-        for (int i = 0; i < samples.size(); i++) {
-            JfrReader.ExecutionSample sample = samples.get(i);
-
-            long duration;
-            if (i == 0) {
-                // we don't really know the duration of the first sample, so just use the sampling
-                // interval
-                duration = this.interval;
-            } else {
-                // calculate the duration of the sample by calculating the time elapsed since the
-                // previous sample
-                duration = TimeUnit.NANOSECONDS.toMicros(sample.time - samples.get(i - 1).time);
-            }
-
+    private <E extends JfrReader.Event> void readSegments(JfrReader reader, SampleCollector<E> collector, Predicate<String> threadFilter, AsyncDataAggregator dataAggregator) throws IOException {
+        List<E> samples = reader.readAllEvents(collector.eventClass());
+        for (E sample : samples) {
             String threadName = reader.threads.get((long) sample.tid);
             if (threadName == null) {
                 continue;
@@ -260,9 +253,11 @@ public class AsyncProfilerJob {
                 continue;
             }
 
+            long value = collector.measure(sample);
+
             // parse the segment and give it to the data aggregator
-            ProfileSegment segment = ProfileSegment.parseSegment(reader, sample, threadName, duration);
-            dataAggregator.insertData(segment, window);
+            ProfileSegment segment = ProfileSegment.parseSegment(reader, sample, threadName, value);
+            dataAggregator.insertData(segment, this.window);
         }
     }
 

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/async/ProfileSegment.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/async/ProfileSegment.java
@@ -38,13 +38,13 @@ public class ProfileSegment {
     /** The stack trace for this segment */
     private final AsyncStackTraceElement[] stackTrace;
     /** The time spent executing this segment in microseconds */
-    private final long time;
+    private final long value;
 
-    public ProfileSegment(int nativeThreadId, String threadName, AsyncStackTraceElement[] stackTrace, long time) {
+    public ProfileSegment(int nativeThreadId, String threadName, AsyncStackTraceElement[] stackTrace, long value) {
         this.nativeThreadId = nativeThreadId;
         this.threadName = threadName;
         this.stackTrace = stackTrace;
-        this.time = time;
+        this.value = value;
     }
 
     public int getNativeThreadId() {
@@ -59,11 +59,11 @@ public class ProfileSegment {
         return this.stackTrace;
     }
 
-    public long getTime() {
-        return this.time;
+    public long getValue() {
+        return this.value;
     }
 
-    public static ProfileSegment parseSegment(JfrReader reader, JfrReader.ExecutionSample sample, String threadName, long duration) {
+    public static ProfileSegment parseSegment(JfrReader reader, JfrReader.Event sample, String threadName, long value) {
         JfrReader.StackTrace stackTrace = reader.stackTraces.get(sample.stackTraceId);
         int len = stackTrace.methods.length;
 
@@ -72,7 +72,7 @@ public class ProfileSegment {
             stack[i] = parseStackFrame(reader, stackTrace.methods[i]);
         }
 
-        return new ProfileSegment(sample.tid, threadName, stack, duration);
+        return new ProfileSegment(sample.tid, threadName, stack, value);
     }
 
     private static AsyncStackTraceElement parseStackFrame(JfrReader reader, long methodId) {

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/async/SampleCollector.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/async/SampleCollector.java
@@ -1,0 +1,154 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.common.sampler.async;
+
+import com.google.common.collect.ImmutableList;
+
+import me.lucko.spark.common.sampler.SamplerMode;
+import me.lucko.spark.common.sampler.async.AsyncProfilerAccess.ProfilingEvent;
+import me.lucko.spark.common.sampler.async.jfr.JfrReader.AllocationSample;
+import me.lucko.spark.common.sampler.async.jfr.JfrReader.Event;
+import me.lucko.spark.common.sampler.async.jfr.JfrReader.ExecutionSample;
+
+import java.util.Collection;
+import java.util.Objects;
+
+/**
+ * Collects and processes sample events for a given type.
+ *
+ * @param <E> the event type
+ */
+public interface SampleCollector<E extends Event> {
+
+    /**
+     * Gets the arguments to initialise the profiler.
+     *
+     * @param access the async profiler access object
+     * @return the initialisation arguments
+     */
+    Collection<String> initArguments(AsyncProfilerAccess access);
+
+    /**
+     * Gets the event class processed by this sample collector.
+     *
+     * @return the event class
+     */
+    Class<E> eventClass();
+
+    /**
+     * Gets the measurements for a given event
+     *
+     * @param event the event
+     * @return the measurement
+     */
+    long measure(E event);
+
+    /**
+     * Gets the mode for the collector.
+     *
+     * @return the mode
+     */
+    SamplerMode getMode();
+
+    /**
+     * Sample collector for execution (cpu time) profiles.
+     */
+    final class Execution implements SampleCollector<ExecutionSample> {
+        private final int interval; // time in microseconds
+
+        public Execution(int interval) {
+            this.interval = interval;
+        }
+
+        @Override
+        public Collection<String> initArguments(AsyncProfilerAccess access) {
+            ProfilingEvent event = access.getProfilingEvent();
+            Objects.requireNonNull(event, "event");
+
+            return ImmutableList.of(
+                    "event=" + event,
+                    "interval=" + this.interval + "us"
+            );
+        }
+
+        @Override
+        public Class<ExecutionSample> eventClass() {
+            return ExecutionSample.class;
+        }
+
+        @Override
+        public long measure(ExecutionSample event) {
+            return event.value() * this.interval;
+        }
+
+        @Override
+        public SamplerMode getMode() {
+            return SamplerMode.EXECUTION;
+        }
+    }
+
+    /**
+     * Sample collector for allocation (memory) profiles.
+     */
+    final class Allocation implements SampleCollector<AllocationSample> {
+        private final int intervalBytes;
+        private final boolean liveOnly;
+
+        public Allocation(int intervalBytes, boolean liveOnly) {
+            this.intervalBytes = intervalBytes;
+            this.liveOnly = liveOnly;
+        }
+
+        public boolean isLiveOnly() {
+            return this.liveOnly;
+        }
+
+        @Override
+        public Collection<String> initArguments(AsyncProfilerAccess access) {
+            ProfilingEvent event = access.getAllocationProfilingEvent();
+            Objects.requireNonNull(event, "event");
+
+            ImmutableList.Builder<String> builder = ImmutableList.builder();
+            builder.add("event=" + event);
+            builder.add("alloc=" + this.intervalBytes);
+            if (this.liveOnly) {
+                builder.add("live");
+            }
+            return builder.build();
+        }
+
+        @Override
+        public Class<AllocationSample> eventClass() {
+            return AllocationSample.class;
+        }
+
+        @Override
+        public long measure(AllocationSample event) {
+            return event.value();
+        }
+
+        @Override
+        public SamplerMode getMode() {
+            return SamplerMode.ALLOCATION;
+        }
+    }
+
+}

--- a/spark-common/src/main/proto/spark/spark.proto
+++ b/spark-common/src/main/proto/spark/spark.proto
@@ -165,6 +165,11 @@ message WindowStatistics {
   int32 entities = 8;
   int32 tile_entities = 9;
   int32 chunks = 10;
+
+  // approximate wall-clock start/end times
+  int64 start_time = 11;
+  int64 end_time = 12;
+  int32 duration = 13;
 }
 
 message RollingAverageValues {

--- a/spark-common/src/main/proto/spark/spark_sampler.proto
+++ b/spark-common/src/main/proto/spark/spark_sampler.proto
@@ -32,6 +32,7 @@ message SamplerMetadata {
   int32 number_of_ticks = 12;
   map<string, SourceMetadata> sources = 13;
   map<string, string> extra_platform_metadata = 14;
+  SamplerMode sampler_mode = 15;
 
   message ThreadDumper {
     Type type = 1;
@@ -66,6 +67,11 @@ message SamplerMetadata {
   message SourceMetadata {
     string name = 1;
     string version = 2;
+  }
+
+  enum SamplerMode {
+    EXECUTION = 0;
+    ALLOCATION = 1;
   }
 }
 


### PR DESCRIPTION
Adds support for allocation/memory profiling. 

Based on the alloc mode in async-profiler. See https://github.com/jvm-profiling-tools/async-profiler#allocation-profiling for more info.

Command usage is: `/spark profiler start --alloc`.

Some advanced options are documented on the docs page: https://spark.lucko.me/docs/Command-Usage#spark-profiler


Corresponding spark-viewer changes: https://github.com/lucko/spark-viewer/commit/a783f5beeefab9105d5ab7d7af7b695b0280669a