### PR TITLE
Fix: Ignore empty mixin packages in FabricClassSourceLookup.

### DIFF
--- a/spark-fabric/src/main/java/me/lucko/spark/fabric/FabricClassSourceLookup.java
+++ b/spark-fabric/src/main/java/me/lucko/spark/fabric/FabricClassSourceLookup.java
@@ -142,7 +142,8 @@ public class FabricClassSourceLookup extends ClassSourceLookup.ByCodeSource {
     private static String modIdFromMixinClass(String mixinClassName) {
         for (Config config : MixinUtils.getMixinConfigs().values()) {
             IMixinConfig mixinConfig = config.getConfig();
-            if (mixinClassName.startsWith(mixinConfig.getMixinPackage())) {
+            String mixinPackage = mixinConfig.getMixinPackage();
+            if (!mixinPackage.isEmpty() && mixinClassName.startsWith(mixinPackage)) {
                 return mixinConfig.getDecoration(FabricUtil.KEY_MOD_ID);
             }
         }


### PR DESCRIPTION
Mixin configs are not required to own a package, e.g. [MixinExtras uses one for initialization only](https://github.com/LlamaLad7/MixinExtras/blob/master/fabric/src/main/resources/mixinextras.init.mixins.json). Such configs are [incorrectly identified as being responsible for merged methods](https://spark.lucko.me/b3079MC5NE) if they happen to appear before the true owning config in the map, since the `startsWith` check will never fail for an empty string.
We should simply ignore any empty packages in the lookup since they cannot own any mixins, [as Mixin itself does](https://github.com/SpongePowered/Mixin/blob/master/src/main/java/org/spongepowered/asm/mixin/transformer/MixinConfig.java#L1186).