### PR TITLE
Add support for Paper Plugins

### DIFF
--- a/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitClassSourceLookup.java
+++ b/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitClassSourceLookup.java
@@ -30,11 +30,22 @@ public class BukkitClassSourceLookup extends ClassSourceLookup.ByClassLoader {
     private static final Class<?> PLUGIN_CLASS_LOADER;
     private static final Field PLUGIN_FIELD;
 
+    private static final Class<?> PAPER_PLUGIN_CLASS_LOADER;
+    private static final Field PAPER_PLUGIN_FIELD;
+
     static {
         try {
             PLUGIN_CLASS_LOADER = Class.forName("org.bukkit.plugin.java.PluginClassLoader");
             PLUGIN_FIELD = PLUGIN_CLASS_LOADER.getDeclaredField("plugin");
             PLUGIN_FIELD.setAccessible(true);
+
+            PAPER_PLUGIN_CLASS_LOADER = getPaperPluginClassLoader();
+            if (PAPER_PLUGIN_CLASS_LOADER != null) {
+                PAPER_PLUGIN_FIELD = PAPER_PLUGIN_CLASS_LOADER.getDeclaredField("loadedJavaPlugin");
+                PAPER_PLUGIN_FIELD.setAccessible(true);
+            } else {
+                PAPER_PLUGIN_FIELD = null;
+            }
         } catch (ReflectiveOperationException e) {
             throw new ExceptionInInitializerError(e);
         }
@@ -45,8 +56,19 @@ public class BukkitClassSourceLookup extends ClassSourceLookup.ByClassLoader {
         if (PLUGIN_CLASS_LOADER.isInstance(loader)) {
             JavaPlugin plugin = (JavaPlugin) PLUGIN_FIELD.get(loader);
             return plugin.getName();
+        } else if (PAPER_PLUGIN_CLASS_LOADER != null && PAPER_PLUGIN_CLASS_LOADER.isInstance(loader)) {
+            JavaPlugin plugin = (JavaPlugin) PAPER_PLUGIN_FIELD.get(loader);
+            return plugin.getName();
         }
         return null;
+    }
+
+    private static Class<?> getPaperPluginClassLoader() {
+        try {
+            return Class.forName("io.papermc.paper.plugin.entrypoint.classloader.PaperPluginClassLoader");
+        } catch (ClassNotFoundException e) {
+            return null;
+        }
     }
 }
 


### PR DESCRIPTION
This adds support for [Paper Plugins](https://docs.papermc.io/paper/reference/paper-plugins) in the plugins/source view of spark-viewer. With this commits, Paper Plugins are correctly recognized as sources without breaking the compatibility with normal Bukkit plugins.