### PR TITLE
feat: give minestom console full permissions

### DIFF
--- a/spark-minestom/src/main/java/me/lucko/spark/minestom/MinestomCommandSender.java
+++ b/spark-minestom/src/main/java/me/lucko/spark/minestom/MinestomCommandSender.java
@@ -60,6 +60,7 @@ public class MinestomCommandSender extends AbstractCommandSender<CommandSender> 
 
     @Override
     public boolean hasPermission(String permission) {
+        if(this.delegate instanceof ConsoleSender) return true;
         return this.delegate.hasPermission(permission);
     }
 }

--- a/spark-minestom/src/main/java/me/lucko/spark/minestom/MinestomCommandSender.java
+++ b/spark-minestom/src/main/java/me/lucko/spark/minestom/MinestomCommandSender.java
@@ -60,7 +60,9 @@ public class MinestomCommandSender extends AbstractCommandSender<CommandSender> 
 
     @Override
     public boolean hasPermission(String permission) {
-        if(this.delegate instanceof ConsoleSender) return true;
+        if (this.delegate instanceof ConsoleSender) {
+            return true;
+        }
         return this.delegate.hasPermission(permission);
     }
 }


### PR DESCRIPTION
The Minestom server console has no permissions by default, and since it would be pretty useful to get profiling without any players online (or when the server does not have a permissions implementation) I added a simple check to give the console sender every permission