### PR TITLE
Fixed typo that bypasses the "backgroundProfilerInterval" config entry

### DIFF
--- a/spark-common/src/main/java/me/lucko/spark/common/util/Configuration.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/util/Configuration.java
@@ -104,7 +104,7 @@ public final class Configuration {
         }
 
         JsonPrimitive val = el.getAsJsonPrimitive();
-        return val.isBoolean() ? val.getAsInt() : def;
+        return val.isNumber() ? val.getAsInt() : def;
     }
 
     public List<String> getStringList(String path) {


### PR DESCRIPTION
This is a rare self-explanatory MR.