### PR TITLE
Fixed --alloc-live-only NPE when trying to parse profiler segments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ subprojects {
 def determinePatchVersion() {
     def tagInfo = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'describe', '--tags', "--always"
+        commandLine 'git', 'describe', '--tags'
         standardOutput = tagInfo
     }
     tagInfo = tagInfo.toString()

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ subprojects {
 def determinePatchVersion() {
     def tagInfo = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'describe', '--tags'
+        commandLine 'git', 'describe', '--tags', "--always"
         standardOutput = tagInfo
     }
     tagInfo = tagInfo.toString()

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/async/ProfileSegment.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/async/ProfileSegment.java
@@ -65,16 +65,9 @@ public class ProfileSegment {
 
     public static ProfileSegment parseSegment(JfrReader reader, JfrReader.Event sample, String threadName, long value) {
         JfrReader.StackTrace stackTrace = reader.stackTraces.get(sample.stackTraceId);
-        int len;
-        AsyncStackTraceElement[] stack;
-        if(stackTrace != null) {
-            len = stackTrace.methods.length;
-            stack = new AsyncStackTraceElement[len];
-        } else {
-            len = 0;
-            stack = new AsyncStackTraceElement[0];
-        }
+        int len = stackTrace != null ? stackTrace.methods.length : 0;
 
+        AsyncStackTraceElement[] stack = new AsyncStackTraceElement[len];
         for (int i = 0; i < len; i++) {
             stack[i] = parseStackFrame(reader, stackTrace.methods[i]);
         }

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/async/ProfileSegment.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/async/ProfileSegment.java
@@ -65,9 +65,16 @@ public class ProfileSegment {
 
     public static ProfileSegment parseSegment(JfrReader reader, JfrReader.Event sample, String threadName, long value) {
         JfrReader.StackTrace stackTrace = reader.stackTraces.get(sample.stackTraceId);
-        int len = stackTrace.methods.length;
+        int len;
+        AsyncStackTraceElement[] stack;
+        if(stackTrace != null) {
+            len = stackTrace.methods.length;
+            stack = new AsyncStackTraceElement[len];
+        } else {
+            len = 0;
+            stack = new AsyncStackTraceElement[0];
+        }
 
-        AsyncStackTraceElement[] stack = new AsyncStackTraceElement[len];
         for (int i = 0; i < len; i++) {
             stack[i] = parseStackFrame(reader, stackTrace.methods[i]);
         }


### PR DESCRIPTION
Additionally fixed git command in one of the build scripts which may fail on some systems.

The NPE was occurring due to --alloc-live-only recording `stackTraceId`s, but stackTraces which were freed weren't recorded and thus causing an NPE. This might need a deeper look, so profiler won't record null stacktraces, but I provided a simple fix that will work as of now