### PR TITLE
Fix background profiler failing to start on Sponge API-8+

### DIFF
--- a/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8SparkPlugin.java
+++ b/spark-sponge8/src/main/java/me/lucko/spark/sponge/Sponge8SparkPlugin.java
@@ -104,7 +104,7 @@ public class Sponge8SparkPlugin implements SparkPlugin {
 
     @Listener
     public void onEnable(StartedEngineEvent<Server> event) {
-        executeSync(() -> this.gameThreadDumper.setThread(Thread.currentThread()));
+        this.gameThreadDumper.setThread(Thread.currentThread());
 
         this.platform = new SparkPlatform(this);
         this.platform.enable();


### PR DESCRIPTION
On Sponge API-8 and above, the background profiler fails to start on server startup with the following exception:
```
[18:05:40] [Server thread/INFO] [spark]: Starting background profiler...
java.lang.NullPointerException: Cannot invoke "java.util.function.Supplier.get()" because "this.threadSupplier" is null
        at me.lucko.spark.common.sampler.ThreadDumper$GameThread.get(ThreadDumper.java:124)
        at me.lucko.spark.sponge.Sponge8SparkPlugin.getDefaultThreadDumper(Sponge8SparkPlugin.java:170)
        at me.lucko.spark.common.sampler.BackgroundSamplerManager.startSampler(BackgroundSamplerManager.java:109)
        at me.lucko.spark.common.sampler.BackgroundSamplerManager.initialise(BackgroundSamplerManager.java:83)
        at me.lucko.spark.common.SparkPlatform.enable(SparkPlatform.java:197)
        at me.lucko.spark.sponge.Sponge8SparkPlugin.onEnable(Sponge8SparkPlugin.java:110)
        at org.spongepowered.common.event.manager.RegisteredListener.handle(RegisteredListener.java:88)
        at org.spongepowered.common.event.manager.SpongeEventManager.post(SpongeEventManager.java:400)
        at org.spongepowered.common.event.manager.SpongeEventManager.post(SpongeEventManager.java:430)
        at org.spongepowered.common.SpongeLifecycle.callStartedEngineEvent(SpongeLifecycle.java:224)
        at net.minecraft.server.dedicated.DedicatedServer.handler$zpl000$vanilla$callStartedEngineAndLoadedGame(DedicatedServer.java:1684)
        at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:201)
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:650)
        at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:266)
        at java.base/java.lang.Thread.run(Thread.java:833)
 ```
 
Since `syncExecutor` is currently always the server scheduler's executor and `StartedEngineEvent<Server>` is run on the server thread, there is no need to sync the `gameThreadDumper.setThread(...)` call.