### PR TITLE
Add a jitpack config file

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17


### PR DESCRIPTION
I've added this, so jitpack.io builds can succeed. I'd like to use jitpack to depend on spark-common, so I can implement my own custom platform in my own app.