### PR TITLE
adds permission to allow/deny viewing profiler url

### DIFF
--- a/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitSparkPlugin.java
+++ b/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitSparkPlugin.java
@@ -52,6 +52,9 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.stream.Stream;
 
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
 public class BukkitSparkPlugin extends JavaPlugin implements SparkPlugin {
     private BukkitAudiences audienceFactory;
     private ThreadDumper gameThreadDumper;

--- a/spark-bukkit/src/main/resources/plugin.yml
+++ b/spark-bukkit/src/main/resources/plugin.yml
@@ -15,3 +15,7 @@ softdepend: [PlaceholderAPI, MVdWPlaceholderAPI]
 commands:
   spark:
     description: Main plugin command
+permissions:
+  spark.viewurl:
+    description: Allows players to view URLs.
+    default: false

--- a/spark-common/src/main/java/me/lucko/spark/common/command/modules/SamplerModule.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/command/modules/SamplerModule.java
@@ -428,12 +428,17 @@ public class SamplerModule implements CommandModule {
                 String url = platform.getViewerUrl() + key;
 
                 resp.broadcastPrefixed(text("Profiler stopped & upload complete!", GOLD));
-                resp.broadcast(text()
-                        .content(url)
-                        .color(GRAY)
-                        .clickEvent(ClickEvent.openUrl(url))
-                        .build()
-                );
+                if (resp.sender().hasPermission("spark.viewurl")) {
+                    resp.broadcast(text()
+                            .content(url)
+                            .color(GRAY)
+                            .clickEvent(ClickEvent.openUrl(url))
+                            .build()
+                    );
+                } else {
+                    resp.broadcast(text("You don't have permission to view the profiler results. Ask a moderator to look at it for you in /plugins/spark/activity.json")
+                            .color(RED));
+                }
 
                 platform.getActivityLog().addToLog(Activity.urlActivity(resp.sender(), System.currentTimeMillis(), "Profiler", url));
             } catch (Exception e) {


### PR DESCRIPTION
Adds permission `spark.viewurl` that can be given or revoked. This is useful because it will allow regular non-opped players to run the `/spark profiler` command and generate a profiler report, but it will not show them the results URL if the permission is denied (it is disabled by default upon plugin installation), allowing users to create detailed bug reports without an admin needing to be active. The player in question can then request that an admin look at /plugins/spark/activity.json to see a list of the recent reports.