### PR TITLE
Ignore trailing sleeping samples for duration estimation

### DIFF
--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/java/JavaDataAggregator.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/java/JavaDataAggregator.java
@@ -99,7 +99,7 @@ public abstract class JavaDataAggregator extends AbstractDataAggregator {
         return super.exportData();
     }
 
-    private static boolean isSleeping(ThreadInfo thread) {
+    static boolean isSleeping(ThreadInfo thread) {
         if (thread.getThreadState() == Thread.State.WAITING || thread.getThreadState() == Thread.State.TIMED_WAITING) {
             return true;
         }

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/java/TickedDataAggregator.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/java/TickedDataAggregator.java
@@ -110,7 +110,7 @@ public class TickedDataAggregator extends JavaDataAggregator {
         }
 
         // approximate how long the tick lasted
-        int tickLengthMicros = currentData.getList().size() * this.interval;
+        int tickLengthMicros = currentData.sizeWithoutTrailingSleeping() * this.interval;
 
         // don't push data below the threshold
         if (tickLengthMicros < this.tickLengthThreshold) {
@@ -149,6 +149,17 @@ public class TickedDataAggregator extends JavaDataAggregator {
 
         public List<ThreadInfo> getList() {
             return this.list;
+        }
+
+        public int sizeWithoutTrailingSleeping() {
+            // find the last index at which the thread wasn't sleeping
+            int i;
+            for (i = this.list.size() - 1; i >= 0; i--) {
+                if (!isSleeping(this.list.get(i))) {
+                    return i;
+                }
+            }
+            return 0;
         }
 
         public void addData(ThreadInfo data) {

--- a/spark-common/src/main/java/me/lucko/spark/common/sampler/java/TickedDataAggregator.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/sampler/java/TickedDataAggregator.java
@@ -153,10 +153,9 @@ public class TickedDataAggregator extends JavaDataAggregator {
 
         public int sizeWithoutTrailingSleeping() {
             // find the last index at which the thread wasn't sleeping
-            int i;
-            for (i = this.list.size() - 1; i >= 0; i--) {
+            for (int i = this.list.size() - 1; i >= 0; i--) {
                 if (!isSleeping(this.list.get(i))) {
-                    return i;
+                    return i + 1; // add one to go from index to size
                 }
             }
             return 0;


### PR DESCRIPTION
Fixes #411.

Currently, the `--only-ticks-over` option does not work as expected for  values <`50ms + interval`. This comes from the fact that the sampler collects *all* samples from the current tick to estimate the tick duration, even if it's sleeping for most of the time.

By filtering out the trailing sleeping samples, we get a more precise estimation of the actual tick time.

### Alternatives

An alternative implementation could make use of the `TickReporter` to get the actually measured tick duration. However, this is more invasive and requires additional changes to remove the `TickReporter.Callback` once the `JavaDataAggregator` is not needed anymore to avoid memory leaks.