### PR TITLE
Use Bukkit#getName() for server name

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -30,9 +30,9 @@ include (
         'spark-velocity4',
         'spark-sponge7',
         'spark-sponge8',
-        'spark-forge',
-        'spark-neoforge',
-        'spark-fabric',
+//        'spark-forge',
+//        'spark-neoforge', // Commented because NeoForge breaks IntellIJ Reload - Remove comments after approval
+//        'spark-fabric',
         'spark-nukkit',
         'spark-waterdog',
         //'spark-minestom', // disabled until minestom publish their maven artifacts to a proper repo

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,9 +30,9 @@ include (
         'spark-velocity4',
         'spark-sponge7',
         'spark-sponge8',
-//        'spark-forge',
-//        'spark-neoforge',
-//        'spark-fabric',
+        'spark-forge',
+        'spark-neoforge',
+        'spark-fabric',
         'spark-nukkit',
         'spark-waterdog',
         //'spark-minestom', // disabled until minestom publish their maven artifacts to a proper repo

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,9 +30,9 @@ include (
         'spark-velocity4',
         'spark-sponge7',
         'spark-sponge8',
-        'spark-forge',
-        'spark-neoforge',
-        'spark-fabric',
+//        'spark-forge',
+//        'spark-neoforge',
+//        'spark-fabric',
         'spark-nukkit',
         'spark-waterdog',
         //'spark-minestom', // disabled until minestom publish their maven artifacts to a proper repo

--- a/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitPlatformInfo.java
+++ b/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitPlatformInfo.java
@@ -41,7 +41,7 @@ public class BukkitPlatformInfo implements PlatformInfo {
 
     @Override
     public String getName() {
-        return "Bukkit";
+        return this.server.getName();
     }
 
     @Override

--- a/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitPlatformInfo.java
+++ b/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitPlatformInfo.java
@@ -47,7 +47,15 @@ public class BukkitPlatformInfo implements PlatformInfo {
 
     @Override
     public String getVersion() {
-        return Bukkit.getName() + " " + this.server.getVersion();
+        final String version = this.server.getVersion();
+        String brand;
+
+        if (version.contains("Spigot")) {
+            brand = null;
+        } else {
+            brand = Bukkit.getName();
+        }
+        return (brand == null ? "" : brand + " ") + this.server.getVersion();
     }
 
     @Override

--- a/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitPlatformInfo.java
+++ b/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitPlatformInfo.java
@@ -22,6 +22,7 @@ package me.lucko.spark.bukkit;
 
 import me.lucko.spark.common.platform.PlatformInfo;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Server;
 
 import java.lang.reflect.Field;
@@ -41,12 +42,12 @@ public class BukkitPlatformInfo implements PlatformInfo {
 
     @Override
     public String getName() {
-        return this.server.getName();
+        return "Bukkit";
     }
 
     @Override
     public String getVersion() {
-        return this.server.getVersion();
+        return Bukkit.getName() + " " + this.server.getVersion();
     }
 
     @Override

--- a/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitPlatformInfo.java
+++ b/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitPlatformInfo.java
@@ -47,12 +47,14 @@ public class BukkitPlatformInfo implements PlatformInfo {
     @Override
     public String getVersion() {
         final String version = this.server.getVersion();
-        String brand;
+        String brand = null;
 
-        if (version.contains("Spigot")) {
-            brand = null;
-        } else {
-            brand = this.server.getName();
+        if (BukkitSparkPlugin.classExists("io.papermc.paper.ServerBuildInfo")) {
+            if (version.contains("Spigot")) {
+                brand = null;
+            } else {
+                brand = this.server.getName();
+            }
         }
         return (brand == null ? "" : brand + " ") + this.server.getVersion();
     }

--- a/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitPlatformInfo.java
+++ b/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitPlatformInfo.java
@@ -22,7 +22,6 @@ package me.lucko.spark.bukkit;
 
 import me.lucko.spark.common.platform.PlatformInfo;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Server;
 
 import java.lang.reflect.Field;
@@ -53,7 +52,7 @@ public class BukkitPlatformInfo implements PlatformInfo {
         if (version.contains("Spigot")) {
             brand = null;
         } else {
-            brand = Bukkit.getName();
+            brand = this.server.getName();
         }
         return (brand == null ? "" : brand + " ") + this.server.getVersion();
     }

--- a/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitSparkPlugin.java
+++ b/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitSparkPlugin.java
@@ -223,7 +223,7 @@ public class BukkitSparkPlugin extends JavaPlugin implements SparkPlugin {
         getServer().getServicesManager().register(Spark.class, api, this, ServicePriority.Normal);
     }
 
-    private static boolean classExists(String className) {
+    protected static boolean classExists(String className) {
         try {
             Class.forName(className);
             return true;

--- a/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitSparkPlugin.java
+++ b/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitSparkPlugin.java
@@ -223,7 +223,7 @@ public class BukkitSparkPlugin extends JavaPlugin implements SparkPlugin {
         getServer().getServicesManager().register(Spark.class, api, this, ServicePriority.Normal);
     }
 
-    protected static boolean classExists(String className) {
+    static boolean classExists(String className) {
         try {
             Class.forName(className);
             return true;


### PR DESCRIPTION
Paper (1.20.6+) Before: ![firefox_W3qNuFf7p9](https://github.com/lucko/spark/assets/40437205/fa78c57c-fd9c-43ed-8120-125df7eecdaf)

Paper After: ![firefox_g9RutfYRN8](https://github.com/lucko/spark/assets/40437205/2aa7cdac-f4ba-446a-a585-9ee2bdc7a397)


Spigot: ![firefox_UZIQFJuCmO](https://github.com/lucko/spark/assets/40437205/74856eab-2c10-4dfc-bf6b-755ac3190dd9)

Maybe need to check if the version contains Spigot then use 'Spigot' as the server name? But imho Spigot..
