### PR TITLE
Check for task completion before sleeping

### DIFF
--- a/spark-common/src/main/java/me/lucko/spark/common/SparkPlatform.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/SparkPlatform.java
@@ -362,12 +362,10 @@ public class SparkPlatform {
             int warningIntervalSeconds = 5;
 
             try {
-                // check once before the initial sleep
-                // this is especially relevant if the executor is/was saturated and runs this task
-                // only after the other already finished
                 if (completed.get()) {
                     return;
                 }
+                
                 for (int i = 1; i <= 3; i++) {
                     try {
                         Thread.sleep(warningIntervalSeconds * 1000);

--- a/spark-common/src/main/java/me/lucko/spark/common/SparkPlatform.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/SparkPlatform.java
@@ -362,6 +362,12 @@ public class SparkPlatform {
             int warningIntervalSeconds = 5;
 
             try {
+                // check once before the initial sleep
+                // this is especially relevant if the executor is/was saturated and runs this task
+                // only after the other already finished
+                if (completed.get()) {
+                    return;
+                }
                 for (int i = 1; i <= 3; i++) {
                     try {
                         Thread.sleep(warningIntervalSeconds * 1000);


### PR DESCRIPTION
As noted in the comment, if the timeout tasks only runs after the command was executed already, we'd run into a 5 second sleep before checking if the command completed already. This normally isn't a problem but takes up 5 seconds of a thread that can't do anything else in that time.

In the case of https://github.com/PaperMC/Paper/issues/11171 there only was one thread available, making the problem obvious pretty fast.