### PR TITLE
Refactor health reporting methods

### DIFF
--- a/spark-common/src/main/java/me/lucko/spark/common/command/modules/HealthModule.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/command/modules/HealthModule.java
@@ -242,8 +242,8 @@ public class HealthModule implements CommandModule {
         }
     }
 
-    private static void uploadHealthReportWithBroadcast(SparkPlatform platform, CommandResponseHandler responseHandler, SparkProtos.HealthData.Builder data) {
-        String key = platform.getBytebinClient().postContent(data.build(), MediaTypes.SPARK_HEALTH_MEDIA_TYPE).key();
+    private static void uploadHealthReportWithBroadcast(SparkPlatform platform, CommandResponseHandler responseHandler, SparkProtos.HealthData.Builder healthData) {
+        String key = platform.getBytebinClient().postContent(healthData.build(), MediaTypes.SPARK_HEALTH_MEDIA_TYPE).key();
         String url = platform.getViewerUrl() + key;
 
         responseHandler.broadcastPrefixed(text("Health report:", GOLD));

--- a/spark-common/src/main/java/me/lucko/spark/common/platform/PlatformStatisticsProvider.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/platform/PlatformStatisticsProvider.java
@@ -154,7 +154,7 @@ public class PlatformStatisticsProvider {
         long uptime = System.currentTimeMillis() - this.platform.getServerNormalOperationStartTime();
         builder.setUptime(uptime);
 
-        addGcStatistics(startingGcStatistics, builder, uptime);
+        addGarbageCollectorStatistics(startingGcStatistics, builder, uptime);
 
         addTickStatistics(builder);
 
@@ -213,7 +213,7 @@ public class PlatformStatisticsProvider {
         );
     }
 
-    private static void addGcStatistics(Map<String, GarbageCollectorStatistics> startingGcStatistics, PlatformStatistics.Builder builder, long uptime) {
+    private static void addGarbageCollectorStatistics(Map<String, GarbageCollectorStatistics> startingGcStatistics, PlatformStatistics.Builder builder, long uptime) {
         if (startingGcStatistics != null) {
             Map<String, GarbageCollectorStatistics> gcStats = GarbageCollectorStatistics.pollStatsSubtractInitial(startingGcStatistics);
             gcStats.forEach((name, statistics) -> builder.putGc(


### PR DESCRIPTION
This PR includes refactoring changes after looking at #436, mainly to split long methods into smaller ones that can be extended in the future. I am happy to revert some of these changes if necessary.

List of changes performed:

HealthModule.java
- Rename 'data' -> 'healthData'
- split code inside try block of 'uploadHealthReport' into 'uploadHealthReportWithBroadcast'.

PlatformStatisticsProvider.java
- Convert for loop to stream, and extract helper method for conciseness
- split 'getPlatformStatistics' into multiple methods that can be extended in the future: 'addMemoryStatistics', 'addGarbageCollectorStatistics', 'addTickStatistics', 'addPingStatistics', 'addPlayerStatistics'.