### PR TITLE
Fix crash on launch

### DIFF
--- a/spark-forge/build.gradle
+++ b/spark-forge/build.gradle
@@ -11,6 +11,7 @@ tasks.withType(JavaCompile) {
 minecraft {
     mappings channel: 'official', version: '1.21.1'
     accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
+    reobf = false
 }
 
 configurations {
@@ -61,11 +62,4 @@ shadowJar {
 artifacts {
     archives shadowJar
     shadow shadowJar
-}
-
-reobf {
-    shadowJar {
-        dependsOn createMcpToSrg
-        mappings = createMcpToSrg.outputs.files.singleFile
-    }
 }


### PR DESCRIPTION
Forge moved to runtime MojMap in 1.20.6+, but you're still remapping the Forge version of your mod to SRG at build time, causing missing method errors. This PR fixes that by skipping the unnecessary reobf step.

Fixes #414
Fixes #440