### PR TITLE
build(neoforge): Merge service files to fix unrelocated adventure module name leaking

### DIFF
--- a/spark-neoforge/build.gradle
+++ b/spark-neoforge/build.gradle
@@ -76,6 +76,8 @@ shadowJar {
     exclude 'META-INF/proguard/**'
     exclude '**/*.proto'
     exclude '**/*.proto.bin'
+
+    mergeServiceFiles()
 }
 
 artifacts {


### PR DESCRIPTION
For service files in META-INF to be relocated, service file merging must be enabled.

Fixes incompatibility with any mod jar-in-jar'ing adventure, or using adventure-platform-neoforge.

https://github.com/jpenilla/squaremap/issues/302