### PR TITLE
Update fabric to 1.21.2

### DIFF
--- a/spark-common/src/main/java/me/lucko/spark/common/command/sender/AbstractCommandSender.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/command/sender/AbstractCommandSender.java
@@ -27,16 +27,20 @@ public abstract class AbstractCommandSender<S> implements CommandSender {
         this.delegate = delegate;
     }
 
+    protected Object getObjectForComparison() {
+        return this.delegate;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         AbstractCommandSender<?> that = (AbstractCommandSender<?>) o;
-        return this.delegate.equals(that.delegate);
+        return this.getObjectForComparison().equals(that.getObjectForComparison());
     }
 
     @Override
     public int hashCode() {
-        return this.delegate.hashCode();
+        return this.getObjectForComparison().hashCode();
     }
 }

--- a/spark-fabric/build.gradle
+++ b/spark-fabric/build.gradle
@@ -28,9 +28,9 @@ configurations {
 
 dependencies {
     // https://modmuss50.me/fabric.html
-    minecraft 'com.mojang:minecraft:1.21.1'
-    mappings 'net.fabricmc:yarn:1.21.1+build.3:v2'
-    modImplementation 'net.fabricmc:fabric-loader:0.15.11'
+    minecraft 'com.mojang:minecraft:1.21.2'
+    mappings 'net.fabricmc:yarn:1.21.2+build.1:v2'
+    modImplementation 'net.fabricmc:fabric-loader:0.16.7'
 
     Set<String> apiModules = [
             "fabric-api-base",
@@ -40,12 +40,12 @@ dependencies {
 
     // Add each module as a dependency
     apiModules.forEach {
-        modImplementation(fabricApi.module(it, '0.102.1+1.21.1'))
+        modImplementation(fabricApi.module(it, '0.106.1+1.21.2'))
     }
 
-    include(modImplementation('me.lucko:fabric-permissions-api:0.3.1'))
+    include(modImplementation('me.lucko:fabric-permissions-api:0.3.2'))
 
-    modImplementation('eu.pb4:placeholder-api:2.4.1+1.21')
+    modImplementation('eu.pb4:placeholder-api:2.5.0+1.21.2')
 
     shade project(':spark-common')
 }

--- a/spark-fabric/src/main/java/me/lucko/spark/fabric/FabricServerCommandSender.java
+++ b/spark-fabric/src/main/java/me/lucko/spark/fabric/FabricServerCommandSender.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of spark.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.lucko.spark.fabric;
+
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import me.lucko.spark.common.command.sender.AbstractCommandSender;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import net.minecraft.entity.Entity;
+import net.minecraft.registry.DynamicRegistryManager;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+
+import java.util.UUID;
+
+public class FabricServerCommandSender extends AbstractCommandSender<ServerCommandSource> {
+    public FabricServerCommandSender(ServerCommandSource commandSource) {
+        super(commandSource);
+    }
+
+    @Override
+    public String getName() {
+        String name = this.delegate.getName();
+        if (this.delegate.getEntity() != null && name.equals("Server")) {
+            return "Console";
+        }
+        return name;
+    }
+
+    @Override
+    public UUID getUniqueId() {
+        Entity entity = this.delegate.getEntity();
+        return entity != null ? entity.getUuid() : null;
+    }
+
+    @Override
+    public void sendMessage(Component message) {
+        Text component = Text.Serialization.fromJsonTree(GsonComponentSerializer.gson().serializeToTree(message), DynamicRegistryManager.EMPTY);
+        this.delegate.sendMessage(component);
+    }
+
+    @Override
+    public boolean hasPermission(String permission) {
+        return Permissions.getPermissionValue(this.delegate, permission).orElseGet(() -> {
+            ServerPlayerEntity player = this.delegate.getPlayer();
+            MinecraftServer server = this.delegate.getServer();
+            if (player != null) {
+                if (server != null && server.isHost(player.getGameProfile())) {
+                    return true;
+                }
+                return player.hasPermissionLevel(4);
+            }
+            return true;
+        });
+    }
+
+    @Override
+    protected Object getObjectForComparison() {
+        UUID uniqueId = getUniqueId();
+        if (uniqueId != null) {
+            return uniqueId;
+        }
+        Entity entity = this.delegate.getEntity();
+        if (entity != null) {
+            return entity;
+        }
+        return getName();
+    }
+}

--- a/spark-fabric/src/main/java/me/lucko/spark/fabric/FabricWorldInfoProvider.java
+++ b/spark-fabric/src/main/java/me/lucko/spark/fabric/FabricWorldInfoProvider.java
@@ -133,20 +133,19 @@ public abstract class FabricWorldInfoProvider implements WorldInfoProvider {
             GameRulesResult data = new GameRulesResult();
             Iterable<ServerWorld> worlds = this.server.getWorlds();
 
-            GameRules.accept(new GameRules.Visitor() {
-                @Override
-                public <T extends GameRules.Rule<T>> void visit(GameRules.Key<T> key, GameRules.Type<T> type) {
-                    String defaultValue = type.createRule().serialize();
-                    data.putDefault(key.getName(), defaultValue);
+            for (ServerWorld world : worlds) {
+                world.getGameRules().accept(new GameRules.Visitor() {
+                    @Override
+                    public <T extends GameRules.Rule<T>> void visit(GameRules.Key<T> key, GameRules.Type<T> type) {
+                        String defaultValue = type.createRule().serialize();
+                        data.putDefault(key.getName(), defaultValue);
 
-                    for (ServerWorld world : worlds) {
                         String worldName = world.getRegistryKey().getValue().getPath();
-
                         String value = world.getGameRules().get(key).serialize();
                         data.put(key.getName(), worldName, value);
                     }
-                }
-            });
+                });
+            }
             return data;
         }
 
@@ -208,28 +207,8 @@ public abstract class FabricWorldInfoProvider implements WorldInfoProvider {
 
         @Override
         public GameRulesResult pollGameRules() {
-            ClientWorld world = this.client.world;
-            if (world == null) {
-                return null;
-            }
-
-            GameRulesResult data = new GameRulesResult();
-
-            String worldName = world.getRegistryKey().getValue().getPath();
-            GameRules worldRules = world.getGameRules();
-
-            GameRules.accept(new GameRules.Visitor() {
-                @Override
-                public <T extends GameRules.Rule<T>> void visit(GameRules.Key<T> key, GameRules.Type<T> type) {
-                    String defaultValue = type.createRule().serialize();
-                    data.putDefault(key.getName(), defaultValue);
-
-                    String value = worldRules.get(key).serialize();
-                    data.put(key.getName(), worldName, value);
-                }
-            });
-
-            return data;
+            // Not available on client since 24w39a
+            return null;
         }
 
         @Override

--- a/spark-fabric/src/main/java/me/lucko/spark/fabric/plugin/FabricClientSparkPlugin.java
+++ b/spark-fabric/src/main/java/me/lucko/spark/fabric/plugin/FabricClientSparkPlugin.java
@@ -32,7 +32,7 @@ import me.lucko.spark.common.platform.world.WorldInfoProvider;
 import me.lucko.spark.common.sampler.ThreadDumper;
 import me.lucko.spark.common.tick.TickHook;
 import me.lucko.spark.common.tick.TickReporter;
-import me.lucko.spark.fabric.FabricCommandSender;
+import me.lucko.spark.fabric.FabricClientCommandSender;
 import me.lucko.spark.fabric.FabricPlatformInfo;
 import me.lucko.spark.fabric.FabricSparkMod;
 import me.lucko.spark.fabric.FabricTickHook;
@@ -43,8 +43,8 @@ import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallba
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.command.CommandRegistryAccess;
-import net.minecraft.server.command.CommandOutput;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
@@ -91,7 +91,7 @@ public class FabricClientSparkPlugin extends FabricSparkPlugin implements Comman
             return 0;
         }
 
-        this.platform.executeCommand(new FabricCommandSender(context.getSource().getEntity(), this), args);
+        this.platform.executeCommand(new FabricClientCommandSender(context.getSource()), args);
         return Command.SINGLE_SUCCESS;
     }
 
@@ -102,17 +102,16 @@ public class FabricClientSparkPlugin extends FabricSparkPlugin implements Comman
             return Suggestions.empty();
         }
 
-        return generateSuggestions(new FabricCommandSender(context.getSource().getEntity(), this), args, builder);
+        return generateSuggestions(new FabricClientCommandSender(context.getSource()), args, builder);
     }
 
     @Override
-    public boolean hasPermission(CommandOutput sender, String permission) {
-        return true;
-    }
-
-    @Override
-    public Stream<FabricCommandSender> getCommandSenders() {
-        return Stream.of(new FabricCommandSender(this.minecraft.player, this));
+    public Stream<FabricClientCommandSender> getCommandSenders() {
+        ClientPlayNetworkHandler networkHandler = this.minecraft.getNetworkHandler();
+        if (networkHandler == null) {
+            return Stream.empty();
+        }
+        return Stream.of(new FabricClientCommandSender(networkHandler.getCommandSource()));
     }
 
     @Override

--- a/spark-fabric/src/main/java/me/lucko/spark/fabric/plugin/FabricServerSparkPlugin.java
+++ b/spark-fabric/src/main/java/me/lucko/spark/fabric/plugin/FabricServerSparkPlugin.java
@@ -27,7 +27,6 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
-import me.lucko.fabric.api.permissions.v0.Permissions;
 import me.lucko.spark.common.monitor.ping.PlayerPingProvider;
 import me.lucko.spark.common.platform.PlatformInfo;
 import me.lucko.spark.common.platform.serverconfig.ServerConfigProvider;
@@ -35,9 +34,9 @@ import me.lucko.spark.common.platform.world.WorldInfoProvider;
 import me.lucko.spark.common.sampler.ThreadDumper;
 import me.lucko.spark.common.tick.TickHook;
 import me.lucko.spark.common.tick.TickReporter;
-import me.lucko.spark.fabric.FabricCommandSender;
 import me.lucko.spark.fabric.FabricPlatformInfo;
 import me.lucko.spark.fabric.FabricPlayerPingProvider;
+import me.lucko.spark.fabric.FabricServerCommandSender;
 import me.lucko.spark.fabric.FabricServerConfigProvider;
 import me.lucko.spark.fabric.FabricSparkMod;
 import me.lucko.spark.fabric.FabricTickHook;
@@ -45,10 +44,9 @@ import me.lucko.spark.fabric.FabricTickReporter;
 import me.lucko.spark.fabric.FabricWorldInfoProvider;
 import me.lucko.spark.fabric.placeholder.SparkFabricPlaceholderApi;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.command.CommandOutput;
 import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.network.ServerPlayerEntity;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
@@ -98,8 +96,7 @@ public class FabricServerSparkPlugin extends FabricSparkPlugin implements Comman
             return 0;
         }
 
-        CommandOutput source = context.getSource().getEntity() != null ? context.getSource().getEntity() : context.getSource().getServer();
-        this.platform.executeCommand(new FabricCommandSender(source, this), args);
+        this.platform.executeCommand(new FabricServerCommandSender(context.getSource()), args);
         return Command.SINGLE_SUCCESS;
     }
 
@@ -110,31 +107,15 @@ public class FabricServerSparkPlugin extends FabricSparkPlugin implements Comman
             return Suggestions.empty();
         }
 
-        return generateSuggestions(new FabricCommandSender(context.getSource().getPlayer(), this), args, builder);
+        return generateSuggestions(new FabricServerCommandSender(context.getSource()), args, builder);
     }
 
     @Override
-    public boolean hasPermission(CommandOutput sender, String permission) {
-        if (sender instanceof PlayerEntity player) {
-            return Permissions.getPermissionValue(player, permission).orElseGet(() -> {
-                MinecraftServer server = player.getServer();
-                if (server != null && server.isHost(player.getGameProfile())) {
-                    return true;
-                }
-
-                return player.hasPermissionLevel(4);
-            });
-        } else {
-            return true;
-        }
-    }
-
-    @Override
-    public Stream<FabricCommandSender> getCommandSenders() {
+    public Stream<FabricServerCommandSender> getCommandSenders() {
         return Stream.concat(
-                this.server.getPlayerManager().getPlayerList().stream(),
-                Stream.of(this.server)
-        ).map(sender -> new FabricCommandSender(sender, this));
+                this.server.getPlayerManager().getPlayerList().stream().map(ServerPlayerEntity::getCommandSource),
+                Stream.of(this.server.getCommandSource())
+        ).map(FabricServerCommandSender::new);
     }
 
     @Override

--- a/spark-fabric/src/main/java/me/lucko/spark/fabric/plugin/FabricSparkPlugin.java
+++ b/spark-fabric/src/main/java/me/lucko/spark/fabric/plugin/FabricSparkPlugin.java
@@ -40,7 +40,6 @@ import me.lucko.spark.fabric.FabricClassSourceLookup;
 import me.lucko.spark.fabric.FabricSparkMod;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.metadata.Person;
-import net.minecraft.server.command.CommandOutput;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -76,8 +75,6 @@ public abstract class FabricSparkPlugin implements SparkPlugin {
         this.platform.disable();
         this.scheduler.shutdown();
     }
-
-    public abstract boolean hasPermission(CommandOutput sender, String permission);
 
     @Override
     public String getVersion() {


### PR DESCRIPTION
Entities no longer implement `CommandOutput`. This means there is no common code (for command sources) between client and server anymore, hence requiring two separate implementations.