### PR TITLE
Prevent duplicate installation on both Mod and Bukkit side

### DIFF
--- a/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitSparkPlugin.java
+++ b/spark-bukkit/src/main/java/me/lucko/spark/bukkit/BukkitSparkPlugin.java
@@ -60,6 +60,15 @@ public class BukkitSparkPlugin extends JavaPlugin implements SparkPlugin {
 
     @Override
     public void onEnable() {
+        boolean detectedSparkMod = classExists("me.lucko.spark.forge.ForgeSparkMod")
+                || classExists("me.lucko.spark.fabric.FabricSparkMod")
+                || classExists("me.lucko.spark.neoforge.NeoForgeSparkMod");
+        if (detectedSparkMod) {
+            getLogger().warning("The spark Bukkit plugin should not be installed when running hybrid Bukkit/modded servers if the spark mod is also installed. Disabling.");
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+
         this.audienceFactory = BukkitAudiences.create(this);
         this.gameThreadDumper = new ThreadDumper.Specific(Thread.currentThread());
 
@@ -98,7 +107,9 @@ public class BukkitSparkPlugin extends JavaPlugin implements SparkPlugin {
 
     @Override
     public void onDisable() {
-        this.platform.disable();
+        if (this.platform != null) {
+            this.platform.disable();
+        }
         if (this.tpsCommand != null) {
             CommandMapUtil.unregisterCommand(this.tpsCommand);
         }


### PR DESCRIPTION
This pull request adds detection to spark-bukkit plugin to prevent duplicate installation on Forge/Fabric/NeoForge+Bukkit hybrid servers, as there're many spark users are running hybrid servers. They may be confused about which spark platform they should use.

## Changes

Added class detection to `onEnable`, determine whether the user installed spark mod. spark-bukkit will disable itself if spark mod platform installation detected.

If there's anything need to change, feel free to leave a comment here( ´▽` )