### PR TITLE
Lazily get game thread when needed

### DIFF
--- a/spark-fabric/src/main/java/me/lucko/spark/fabric/plugin/FabricClientSparkPlugin.java
+++ b/spark-fabric/src/main/java/me/lucko/spark/fabric/plugin/FabricClientSparkPlugin.java
@@ -58,7 +58,7 @@ public class FabricClientSparkPlugin extends MinecraftClientSparkPlugin<FabricSp
     }
 
     public FabricClientSparkPlugin(FabricSparkMod mod, Minecraft minecraft) {
-        super(mod, minecraft, ((MinecraftAccessor) minecraft).getGameThread());
+        super(mod, minecraft, ((MinecraftAccessor) minecraft)::getGameThread);
     }
 
     @Override

--- a/spark-forge/src/main/java/me/lucko/spark/forge/plugin/ForgeClientSparkPlugin.java
+++ b/spark-forge/src/main/java/me/lucko/spark/forge/plugin/ForgeClientSparkPlugin.java
@@ -62,7 +62,7 @@ public class ForgeClientSparkPlugin extends MinecraftClientSparkPlugin<ForgeSpar
     private Collection<EventListener> listeners = Collections.emptyList();
 
     public ForgeClientSparkPlugin(ForgeSparkMod mod, Minecraft minecraft) {
-        super(mod, minecraft, minecraft.gameThread);
+        super(mod, minecraft, () -> minecraft.gameThread);
     }
 
     @Override

--- a/spark-minecraft/src/main/java/me/lucko/spark/minecraft/plugin/MinecraftClientSparkPlugin.java
+++ b/spark-minecraft/src/main/java/me/lucko/spark/minecraft/plugin/MinecraftClientSparkPlugin.java
@@ -32,16 +32,17 @@ import me.lucko.spark.minecraft.SparkMinecraftMod;
 import net.minecraft.client.Minecraft;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 public abstract class MinecraftClientSparkPlugin<M extends SparkMinecraftMod, CS> extends MinecraftSparkPlugin<M> implements Command<CS>, SuggestionProvider<CS> {
 
     protected final Minecraft minecraft;
     private final ThreadDumper.GameThread gameThreadDumper;
 
-    public MinecraftClientSparkPlugin(M mod, Minecraft minecraft, Thread gameThread) {
+    public MinecraftClientSparkPlugin(M mod, Minecraft minecraft, Supplier<Thread> gameThreadSupplier) {
         super(mod);
         this.minecraft = minecraft;
-        this.gameThreadDumper = new ThreadDumper.GameThread(() -> gameThread);
+        this.gameThreadDumper = new ThreadDumper.GameThread(gameThreadSupplier);
     }
 
     protected abstract CommandSender createCommandSender(CS source);

--- a/spark-neoforge/src/main/java/me/lucko/spark/neoforge/plugin/NeoForgeClientSparkPlugin.java
+++ b/spark-neoforge/src/main/java/me/lucko/spark/neoforge/plugin/NeoForgeClientSparkPlugin.java
@@ -56,7 +56,7 @@ public class NeoForgeClientSparkPlugin extends MinecraftClientSparkPlugin<NeoFor
     }
 
     public NeoForgeClientSparkPlugin(NeoForgeSparkMod mod, Minecraft minecraft) {
-        super(mod, minecraft, minecraft.gameThread);
+        super(mod, minecraft, () -> minecraft.gameThread);
     }
 
     @Override


### PR DESCRIPTION
Fixes #543 

Spark reads `null` as the game thread at the point of initialization. I wasn't able to really figure out why that changed with 1.21.11, but given how the information is used, it makes sense to just use a supplier directly and access the game thread when needed.

Tested on Fabric for 1.21.11.