### PR TITLE
Migrate to Windows registry

### DIFF
--- a/spark-common/src/main/java/me/lucko/spark/common/monitor/WindowsReg.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/monitor/WindowsReg.java
@@ -29,26 +29,28 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Utility for reading from wmic (Windows Management Instrumentation Commandline) on Windows systems.
+ * Utility for reading from Windows Registry on Windows systems.
+ * A replacement for deprecated WMIC.
  */
-@Deprecated
-public enum WindowsWmic {
+public enum WindowsReg {
 
     /**
-     * Gets the CPU name
+     * Gets the CPU name from the registry
      */
-    CPU_GET_NAME("wmic", "cpu", "get", "name", "/FORMAT:list"),
+    CPU_GET_NAME("reg", "query", "HKLM\\HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0", "/v", "ProcessorNameString"),
 
     /**
-     * Gets the operating system name (caption) and version.
+     * Gets the operating system name (ProductName) and version (CurrentBuild).
+     * Modern JVMs handle OS name/version natively via System.getProperty,
+     * but this is retained if native registry readout is strictly needed.
      */
-    OS_GET_CAPTION_AND_VERSION("wmic", "os", "get", "caption,version", "/FORMAT:list");
+    OS_GET_INFO("reg", "query", "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion");
 
     private static final boolean SUPPORTED = System.getProperty("os.name").startsWith("Windows");
 
     private final String[] cmdArgs;
 
-    WindowsWmic(String... cmdArgs) {
+    WindowsReg(String... cmdArgs) {
         this.cmdArgs = cmdArgs;
     }
 
@@ -57,19 +59,15 @@ public enum WindowsWmic {
             ProcessBuilder process = new ProcessBuilder(this.cmdArgs).redirectErrorStream(true);
             try (BufferedReader buf = new BufferedReader(new InputStreamReader(process.start().getInputStream()))) {
                 List<String> lines = new ArrayList<>();
-
                 String line;
                 while ((line = buf.readLine()) != null) {
-                    lines.add(line);
+                    if (!line.trim().isEmpty()) {
+                        lines.add(line);
+                    }
                 }
-
                 return lines;
-            } catch (Exception e) {
-                // ignore
-            }
+            } catch (Exception ignored) { }
         }
-
         return Collections.emptyList();
     }
 }
-

--- a/spark-common/src/main/java/me/lucko/spark/common/monitor/cpu/CpuInfo.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/monitor/cpu/CpuInfo.java
@@ -22,7 +22,7 @@ package me.lucko.spark.common.monitor.cpu;
 
 import me.lucko.spark.common.monitor.LinuxProc;
 import me.lucko.spark.common.monitor.MacosSysctl;
-import me.lucko.spark.common.monitor.WindowsWmic;
+import me.lucko.spark.common.monitor.WindowsReg;
 
 import java.util.regex.Pattern;
 
@@ -47,9 +47,13 @@ public enum CpuInfo {
             }
         }
 
-        for (String line : WindowsWmic.CPU_GET_NAME.read()) {
-            if (line.startsWith("Name")) {
-                return line.substring(5).trim();
+        for (String line : WindowsReg.CPU_GET_NAME.read()) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("ProcessorNameString")) {
+                int index = trimmed.indexOf("REG_SZ");
+                if (index != -1) {
+                    return trimmed.substring(index + 6).trim();
+                }
             }
         }
 

--- a/spark-common/src/main/java/me/lucko/spark/common/monitor/os/OperatingSystemInfo.java
+++ b/spark-common/src/main/java/me/lucko/spark/common/monitor/os/OperatingSystemInfo.java
@@ -21,7 +21,7 @@
 package me.lucko.spark.common.monitor.os;
 
 import me.lucko.spark.common.monitor.LinuxProc;
-import me.lucko.spark.common.monitor.WindowsWmic;
+import me.lucko.spark.common.monitor.WindowsReg;
 
 /**
  * Small utility to query the operating system name & version.
@@ -59,15 +59,35 @@ public final class OperatingSystemInfo {
             }
         }
 
-        for (String line : WindowsWmic.OS_GET_CAPTION_AND_VERSION.read()) {
-            if (line.startsWith("Caption") && line.length() > 18) {
-                // Caption=Microsoft Windows something
-                // \----------------/ = 18 chars
-                name = line.substring(18).trim();
-            } else if (line.startsWith("Version")) {
-                // Version=10.0.something
-                // \------/ = 8 chars
-                version = line.substring(8).trim();
+        String winName = null;
+        String winBuild = null;
+
+        for (String line : WindowsReg.OS_GET_INFO.read()) {
+            String trimmed = line.trim();
+
+            if (trimmed.startsWith("ProductName")) {
+                int index = trimmed.indexOf("REG_SZ");
+                if (index != -1) {
+                    winName = trimmed.substring(index + 6).trim();
+                }
+            }
+            else if (trimmed.startsWith("CurrentBuild")) {
+                int index = trimmed.indexOf("REG_SZ");
+                if (index != -1) {
+                    winBuild = trimmed.substring(index + 6).trim();
+                }
+            }
+
+            if (winName != null && winBuild != null) {
+                break;
+            }
+        }
+
+        if (winName != null) {
+            if (winBuild != null && !winBuild.isEmpty()) {
+                name = winName + " (Build " + winBuild + ")";
+            } else {
+                name = winName;
             }
         }
 


### PR DESCRIPTION
Migrate from WMIC to the Windows Registry for getting system info.

Microsoft has deprecated WMIC and removed it in Windows 11 25H2. Relying on it may lead to missing CPU and OS information.

### Info retrieved from Registry

<img width="1519" height="63" alt="image" src="https://github.com/user-attachments/assets/116dc1fa-f08f-428e-bf25-e21fbcef82b8" />

Currently Windows 11 will be detected as Windows 10, but can be identified via the trailing build number.
