### PR TITLE
Update adventure library to v5

### DIFF
--- a/spark-common/build.gradle
+++ b/spark-common/build.gradle
@@ -4,6 +4,12 @@ plugins {
     id 'maven-publish'
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
 license {
     exclude '**/sampler/async/jfr/**'
     exclude {
@@ -22,20 +28,15 @@ dependencies {
         exclude(module: 'slf4j-api')
     }
 
-    api('net.kyori:adventure-api:4.21.0') {
-        exclude(module: 'adventure-bom')
+    api(platform('net.kyori:adventure-bom:5.1.1'))
+    api('net.kyori:adventure-api') {
         exclude(module: 'checker-qual')
         exclude(module: 'annotations')
     }
-    api('net.kyori:adventure-text-serializer-gson:4.21.0') {
-        exclude(module: 'adventure-bom')
-        exclude(module: 'adventure-api')
+    api('net.kyori:adventure-text-serializer-gson') {
         exclude(module: 'gson')
     }
-    api('net.kyori:adventure-text-serializer-legacy:4.21.0') {
-        exclude(module: 'adventure-bom')
-        exclude(module: 'adventure-api')
-    }
+    api('net.kyori:adventure-text-serializer-legacy')
     implementation('net.kyori:adventure-text-feature-pagination:4.0.0-SNAPSHOT') {
         exclude(module: 'adventure-api')
     }
@@ -52,10 +53,7 @@ dependencies {
     testImplementation 'com.google.guava:guava:19.0'
     testImplementation 'org.jspecify:jspecify:1.0.0'
 
-    testImplementation('net.kyori:adventure-text-serializer-ansi:4.17.0') {
-        exclude(module: 'adventure-bom')
-        exclude(module: 'adventure-api')
-    }
+    testImplementation('net.kyori:adventure-text-serializer-ansi')
 }
 
 protobuf {
@@ -82,6 +80,10 @@ sourceSets {
             }
         }
     }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.release = 21
 }
 
 test {

--- a/spark-paper/build.gradle
+++ b/spark-paper/build.gradle
@@ -3,9 +3,14 @@ plugins {
     id 'maven-publish'
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 tasks.withType(JavaCompile) {
-    // override, compile targeting J21
-    options.release = 21
+    options.release = 25
 }
 
 tasks.jar {
@@ -14,7 +19,7 @@ tasks.jar {
 
 dependencies {
     implementation project(':spark-common')
-    compileOnly 'io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT'
+    compileOnly 'io.papermc.paper:paper-api:26.2.build.29-alpha'
 }
 
 repositories {


### PR DESCRIPTION

The problem is in `CommandResponseHandler`, which builds a static prefix component on class load. In Adventure 4, `build()` returned `BuildableComponent`. In Adventure 5, it returns `Component`.

This PR fixes that by recompiling against Adventure 5.1.1, which is what Paper 26.2 actually ships.

Related Paper issue: https://github.com/PaperMC/Paper/issues/13966

## What changed

- Bumped `spark-common` from Adventure 4.21.0 to the Adventure 5.1.1 BOM
- Set `spark-common` to compile with Java 21
- Set `spark-paper` to compile with Java 25, matching Paper 26.2
- Updated the Paper API dependency to `26.2.build.29-alpha`

## How I tested it

- [x] Built `spark-paper` locally and published it to Maven local
- [x] Built Paper 26.2 against that Spark build
- [x] Started a server and confirmed Spark loads without the `NoSuchMethodError`
- [x] Verified the background profiler starts and `/spark` commands works normally